### PR TITLE
fix #24 #28 Windows right-click menu disappears

### DIFF
--- a/obsidian-projects/src/components/core/DataGrid/GridHeader.svelte
+++ b/obsidian-projects/src/components/core/DataGrid/GridHeader.svelte
@@ -4,7 +4,7 @@
 	import { Icon, IconButton } from "obsidian-svelte";
 
 	import { GridCell, TextLabel } from "./GridCell";
-	import { fieldIcon, type GridColDef } from "./data-grid";
+	import { fieldIcon, menuOnContextMenu, type GridColDef } from "./data-grid";
 
 	import GridCellGroup from "./GridCellGroup.svelte";
 	import { DataFieldType } from "../../../lib/types";
@@ -19,7 +19,7 @@
 	): (event: MouseEvent) => void {
 		return (event: MouseEvent) => {
 			if (event.button === 2) {
-				onColumnMenu(column).showAtMouseEvent(event);
+				menuOnContextMenu(event, onColumnMenu(column));
 			}
 		};
 	}

--- a/obsidian-projects/src/components/core/DataGrid/GridRow.svelte
+++ b/obsidian-projects/src/components/core/DataGrid/GridRow.svelte
@@ -8,6 +8,7 @@
 	import GridCellGroup from "./GridCellGroup.svelte";
 
 	import type { GridColDef, GridRowId, GridRowModel } from "./data-grid";
+	import { menuOnContextMenu } from "./data-grid";
 
 	import { setContext } from "svelte";
 
@@ -30,7 +31,7 @@
 	function handleHeaderClick(): (event: MouseEvent) => void {
 		return (event: MouseEvent) => {
 			if (event.button === 2) {
-				onRowMenu(rowId, row).showAtMouseEvent(event);
+				menuOnContextMenu(event, onRowMenu(rowId, row));
 			}
 		};
 	}
@@ -41,7 +42,7 @@
 	): (event: MouseEvent) => void {
 		return (event: MouseEvent) => {
 			if (event.button === 2) {
-				onCellMenu(rowId, column, value).showAtMouseEvent(event);
+				menuOnContextMenu(event, onCellMenu(rowId, column, value));
 			}
 
 			if (event.target instanceof HTMLTableCellElement) {

--- a/obsidian-projects/src/components/core/DataGrid/data-grid.ts
+++ b/obsidian-projects/src/components/core/DataGrid/data-grid.ts
@@ -1,3 +1,4 @@
+import type { Menu } from "obsidian";
 import { DataFieldType, isNumber } from "../../../lib/types";
 
 export type GridValidRowModel = { [key: string]: any };
@@ -78,4 +79,14 @@ export function sortRows(
 			return 0;
 		}
 	});
+}
+
+export function menuOnContextMenu(event: MouseEvent, menu: Menu): void {
+	const contextMenuFunc = (event: MouseEvent) => {
+		window.removeEventListener("contextmenu", contextMenuFunc);
+		event.preventDefault();
+		event.stopPropagation();
+		menu.showAtMouseEvent(event);
+	}
+	window.addEventListener('contextmenu', contextMenuFunc, false);
 }


### PR DESCRIPTION
I still want to do some more digging maybe this weekend to figure out more of the "why" of the problem, but bottom-line the issue was that the right clicks were being done by a `mousedown` event which showed the menu but then on the mouse up (finishing of the click) Obsidian natively seems to then trigger the "contextmenu" event which then clears any menus that are already opened. I think there are some "timing issues" with it and also I think there are way too many event listeners running / conflicting overall that I want to look into another day but I at least have a solution 🙂 I would also like to see what Licat / other devs have to say about this potential issue with "custom context menus" because I seem to remember a warning a long time ago that it can get a little messy.

Basically I now turn the `mousedown` event into a trigger to add a context menu window event listener at which it adds the menu at that point on the context menu and then stops the default and propagation. So now the menu is actually not loading / firing officially until the `contextmenu` event which is after the mouse up and click events.