### PR TITLE
Move metadata to onOpen and add view id

### DIFF
--- a/obsidian-projects-types/README.md
+++ b/obsidian-projects-types/README.md
@@ -54,10 +54,7 @@ class MySampleView extends ProjectView {
   // Whenever this function is called, you should invalidate previous data.
   //
   // `data`        Contains the parsed data.
-  // `readonly`    If true, you should disable any UI features that updates the
-  //               underlying data. Currently, readonly is only true for
-  //               Dataview projects, where fields may be computed.
-  async onData({ data, readonly }: DataQueryResult) {
+  async onData({ data }: DataQueryResult) {
     if (this.dataEl) {
       this.dataEl.empty();
       this.dataEl.createDiv({ text: JSON.stringify(data.fields) });
@@ -70,7 +67,10 @@ class MySampleView extends ProjectView {
   // `contentEl`    HTML element where you can attach your view.
   // `config`       JSON object with optional view configuration.
   // `saveConfig`   Callback to save configuration changes.
-  async onOpen({ contentEl, config, saveConfig }: ProjectViewProps) {
+  // `readonly`     If true, you should disable any UI features that updates the
+  //                underlying data. Currently, readonly is only true for
+  //                Dataview projects, where fields may be computed.
+  async onOpen({ contentEl, config, saveConfig, readonly }: ProjectViewProps) {
     console.log("Opening ", this.getDisplayName());
 
     contentEl.createEl("h1", { text: "My Sample View" });

--- a/obsidian-projects-types/index.ts
+++ b/obsidian-projects-types/index.ts
@@ -92,16 +92,19 @@ export interface ProjectDefinition {
   readonly dataview?: boolean;
   readonly query?: string;
 }
+
 export interface DataQueryResult {
-  viewApi: ViewApi;
-  project: ProjectDefinition;
-  readonly: boolean;
   data: DataFrame;
 }
+
 export interface ProjectViewProps<T = Record<string, any>> {
+  viewId: string;
+  project: ProjectDefinition;
   config: T;
   saveConfig: (config: T) => void;
   contentEl: HTMLElement;
+  viewApi: ViewApi;
+  readonly: boolean;
 }
 
 export abstract class ProjectView<T = Record<string, any>> {

--- a/obsidian-projects-types/package.json
+++ b/obsidian-projects-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-projects-types",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "types": "index.d.ts",
   "scripts": {
     "build": "tsc"

--- a/src/app/onboarding/demo-project.ts
+++ b/src/app/onboarding/demo-project.ts
@@ -4,7 +4,7 @@ import { settings } from "src/lib/stores/settings";
 import type { BoardConfig } from "src/views/Board/types";
 import type { CalendarConfig } from "src/views/Calendar/types";
 import type { GalleryConfig } from "src/views/Gallery/types";
-import type { GridConfig } from "src/views/Table/types";
+import type { TableConfig } from "src/views/Table/types";
 import { v4 as uuidv4 } from "uuid";
 
 export async function createDemoProject(vault: Vault) {
@@ -69,7 +69,7 @@ export async function createDemoProject(vault: Vault) {
     );
   }
 
-  const tableConfig: GridConfig = {
+  const tableConfig: TableConfig = {
     fieldConfig: {
       name: {
         width: 360,

--- a/src/custom-view-api.ts
+++ b/src/custom-view-api.ts
@@ -3,16 +3,17 @@ import type { ViewApi } from "./lib/view-api";
 import type { ProjectDefinition } from "./types";
 
 export interface DataQueryResult {
-  viewApi: ViewApi;
-  project: ProjectDefinition;
-  readonly: boolean;
   data: DataFrame;
 }
 
 export interface ProjectViewProps<T = Record<string, any>> {
+  viewId: string;
+  project: ProjectDefinition;
   config: T;
   saveConfig: (config: T) => void;
   contentEl: HTMLElement;
+  viewApi: ViewApi;
+  readonly: boolean;
 }
 
 export abstract class ProjectView<T = Record<string, any>> {

--- a/src/views/Board/board-view.ts
+++ b/src/views/Board/board-view.ts
@@ -20,31 +20,22 @@ export class BoardView extends ProjectView<BoardConfig> {
     return "columns";
   }
 
-  async onData(result: DataQueryResult) {
-    if (!this.view && this.props) {
-      this.view = new BoardViewSvelte({
-        target: this.props.contentEl,
-        props: {
-          frame: result.data ?? { fields: [], records: [] },
-          api: result.viewApi,
-          project: result.project,
-          readonly: result.readonly,
-          config: this.props.config,
-          onConfigChange: this.props.saveConfig,
-        },
-      });
-    } else {
-      this.view?.$set({
-        frame: result.data,
-        api: result.viewApi,
-        project: result.project,
-        readonly: result.readonly,
-      });
-    }
+  async onData({ data }: DataQueryResult) {
+    this.view?.$set({ frame: data });
   }
 
   async onOpen(props: ProjectViewProps<BoardConfig>) {
-    this.props = props;
+    this.view = new BoardViewSvelte({
+      target: props.contentEl,
+      props: {
+        frame: { fields: [], records: [] },
+        api: props.viewApi,
+        project: props.project,
+        readonly: props.readonly,
+        config: props.config,
+        onConfigChange: props.saveConfig,
+      },
+    });
   }
 
   async onClose() {

--- a/src/views/Calendar/calendar-view.ts
+++ b/src/views/Calendar/calendar-view.ts
@@ -20,31 +20,22 @@ export class CalendarView extends ProjectView<CalendarConfig> {
     return "calendar";
   }
 
-  async onData(result: DataQueryResult) {
-    if (!this.view && this.props) {
-      this.view = new CalendarViewSvelte({
-        target: this.props.contentEl,
-        props: {
-          frame: result.data ?? { fields: [], records: [] },
-          api: result.viewApi,
-          project: result.project,
-          readonly: result.readonly,
-          config: this.props.config,
-          onConfigChange: this.props.saveConfig,
-        },
-      });
-    } else {
-      this.view?.$set({
-        frame: result.data,
-        api: result.viewApi,
-        project: result.project,
-        readonly: result.readonly,
-      });
-    }
+  async onData({ data }: DataQueryResult) {
+    this.view?.$set({ frame: data });
   }
 
   async onOpen(props: ProjectViewProps<CalendarConfig>) {
-    this.props = props;
+    this.view = new CalendarViewSvelte({
+      target: props.contentEl,
+      props: {
+        frame: { fields: [], records: [] },
+        api: props.viewApi,
+        project: props.project,
+        readonly: props.readonly,
+        config: props.config,
+        onConfigChange: props.saveConfig,
+      },
+    });
   }
 
   async onClose() {

--- a/src/views/Custom/CustomView.svelte
+++ b/src/views/Custom/CustomView.svelte
@@ -20,20 +20,28 @@
     dataProps: DataQueryResult;
     config: Record<string, any>;
     onConfigChange: (config: Record<string, any>) => void;
+    viewApi: ViewApi;
+    readonly: boolean;
+    project: ProjectDefinition;
   }
 
   function useView(node: HTMLElement, props: ViewProps) {
     // Keep track of previous view id to determine if view should be invalidated.
     let viewId = props.view.id;
+    let projectId = props.project.id;
 
     let projectView = $customViews[props.view.type];
 
     if (projectView) {
       // Component just mounted, so treat all properties as dirty.
       projectView.onOpen({
+        viewId: props.view.id,
+        project: props.project,
         contentEl: node,
         config: props.config,
         saveConfig: props.onConfigChange,
+        viewApi: props.viewApi,
+        readonly: props.readonly,
       });
       projectView.onData(props.dataProps);
     }
@@ -41,7 +49,8 @@
     return {
       update(newprops: ViewProps) {
         // User switched to a different view.
-        const dirty = newprops.view.id !== viewId;
+        const dirty =
+          newprops.view.id !== viewId || newprops.project.id !== projectId;
 
         if (dirty) {
           // Clean up previous view.
@@ -55,6 +64,10 @@
           if (projectView) {
             projectView.onOpen({
               contentEl: node,
+              viewId: newprops.view.id,
+              project: newprops.project,
+              viewApi: newprops.viewApi,
+              readonly: newprops.readonly,
               config: newprops.config,
               saveConfig: newprops.onConfigChange,
             });
@@ -78,10 +91,10 @@
     view,
     dataProps: {
       data: frame,
-      viewApi: api,
-      project,
-      readonly,
     },
+    viewApi: api,
+    project,
+    readonly,
     config,
     onConfigChange,
   }}

--- a/src/views/Gallery/gallery-view.ts
+++ b/src/views/Gallery/gallery-view.ts
@@ -20,31 +20,22 @@ export class GalleryView extends ProjectView<GalleryConfig> {
     return "layout-grid";
   }
 
-  async onData(result: DataQueryResult) {
-    if (!this.view && this.props) {
-      this.view = new GalleryViewSvelte({
-        target: this.props.contentEl,
-        props: {
-          frame: result.data ?? { fields: [], records: [] },
-          api: result.viewApi,
-          project: result.project,
-          readonly: result.readonly,
-          config: this.props.config,
-          onConfigChange: this.props.saveConfig,
-        },
-      });
-    } else {
-      this.view?.$set({
-        frame: result.data,
-        api: result.viewApi,
-        project: result.project,
-        readonly: result.readonly,
-      });
-    }
+  async onData({ data }: DataQueryResult) {
+    this.view?.$set({ frame: data });
   }
 
   async onOpen(props: ProjectViewProps<GalleryConfig>) {
-    this.props = props;
+    this.view = new GalleryViewSvelte({
+      target: props.contentEl,
+      props: {
+        frame: { fields: [], records: [] },
+        api: props.viewApi,
+        project: props.project,
+        readonly: props.readonly,
+        config: props.config,
+        onConfigChange: props.saveConfig,
+      },
+    });
   }
 
   async onClose() {

--- a/src/views/Table/TableView.svelte
+++ b/src/views/Table/TableView.svelte
@@ -17,7 +17,7 @@
 
   import type { DataFrame } from "../../lib/data";
   import type { ProjectDefinition } from "../../types";
-  import type { GridConfig } from "./types";
+  import type { TableConfig } from "./types";
   import { HorizontalGroup } from "src/components/HorizontalGroup";
   import { ToolBar } from "src/components/ToolBar";
   import type { ViewApi } from "src/lib/view-api";
@@ -27,8 +27,8 @@
   export let readonly: boolean;
   export let api: ViewApi;
 
-  export let config: GridConfig | undefined;
-  export let onConfigChange: (cfg: GridConfig) => void;
+  export let config: TableConfig | undefined;
+  export let onConfigChange: (cfg: TableConfig) => void;
 
   $: ({ fields, records } = frame);
 

--- a/src/views/Table/table-view.ts
+++ b/src/views/Table/table-view.ts
@@ -4,9 +4,9 @@ import {
   type ProjectViewProps,
 } from "src/custom-view-api";
 import TableViewSvelte from "./TableView.svelte";
-import type { GridConfig } from "./types";
+import type { TableConfig } from "./types";
 
-export class TableView extends ProjectView<GridConfig> {
+export class TableView extends ProjectView<TableConfig> {
   view?: TableViewSvelte | null;
   props?: ProjectViewProps;
 
@@ -20,31 +20,22 @@ export class TableView extends ProjectView<GridConfig> {
     return "table";
   }
 
-  async onData(result: DataQueryResult) {
-    if (!this.view && this.props) {
-      this.view = new TableViewSvelte({
-        target: this.props.contentEl,
-        props: {
-          frame: result.data ?? { fields: [], records: [] },
-          api: result.viewApi,
-          project: result.project,
-          readonly: result.readonly,
-          config: this.props.config,
-          onConfigChange: this.props.saveConfig,
-        },
-      });
-    } else {
-      this.view?.$set({
-        frame: result.data,
-        api: result.viewApi,
-        project: result.project,
-        readonly: result.readonly,
-      });
-    }
+  async onData({ data }: DataQueryResult) {
+    this.view?.$set({ frame: data });
   }
 
-  async onOpen(props: ProjectViewProps<GridConfig>) {
-    this.props = props;
+  async onOpen(props: ProjectViewProps<TableConfig>) {
+    this.view = new TableViewSvelte({
+      target: props.contentEl,
+      props: {
+        frame: { fields: [], records: [] },
+        api: props.viewApi,
+        project: props.project,
+        readonly: props.readonly,
+        config: props.config,
+        onConfigChange: props.saveConfig,
+      },
+    });
   }
 
   async onClose() {

--- a/src/views/Table/types.ts
+++ b/src/views/Table/types.ts
@@ -5,7 +5,7 @@ export interface FieldConfig {
   };
 }
 
-export interface GridConfig {
+export interface TableConfig {
   readonly fieldConfig?: FieldConfig;
   readonly sortField?: string;
   readonly sortAsc?: boolean;


### PR DESCRIPTION
## What happened?

This pull request introduces a breaking change and an addition to the Custom View API. 

- BREAKING CHANGE: All props except `data` have been moved from `DataQueryResult` to `ProjectViewProps`. These props never change while the view is open. The underlying functionality remains the same.
- ProjectViewProps now includes the view id, a UUID that uniquely identifies a specific view.

## What should I do?

Update to 0.6.0 of `obsidian-projects-types`.

Notifying @RafaelGB @Quorafind 