### PR TITLE
Force fallback for Sortable

### DIFF
--- a/src/app/toolbar/ViewItemList.svelte
+++ b/src/app/toolbar/ViewItemList.svelte
@@ -12,6 +12,7 @@
       direction: () => "horizontal",
       animation: 100,
       dataIdAttr: "data-id",
+      forceFallback: true,
       onSort: () => onSort(sortable.toArray()),
     });
   });

--- a/src/views/Board/components/Board/Board.svelte
+++ b/src/views/Board/components/Board/Board.svelte
@@ -23,9 +23,10 @@
 
   onMount(() => {
     sortable = Sortable.create(ref, {
-      animation: 150,
+      animation: 100,
       direction: "horizontal",
       dataIdAttr: "data-id",
+      forceFallback: true,
       store: {
         get() {
           return columns.map((column) => column.id);

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,7 @@
 .workspace-leaf-content[data-type="obsidian-projects"] .view-content {
   padding: 0;
 }
+
+.sortable-drag {
+  opacity: 0 !important;
+}


### PR DESCRIPTION
SortableJS' native HTML5 implementation seems to have some performance issues. This PR uses the fallback implementation which seems to work better.

Fixes #139