### PR TITLE
Add option to exclude notes from project

### DIFF
--- a/src/components/FileListInput/FileListInput.svelte
+++ b/src/components/FileListInput/FileListInput.svelte
@@ -6,6 +6,7 @@
 
   export let paths: string[];
   export let onPathsChange: (value: string[]) => void;
+  export let buttonText: string;
 </script>
 
 {#each paths as path, i}
@@ -36,7 +37,7 @@
 <Button
   on:click={() => {
     onPathsChange([...paths, ""]);
-  }}>Add template</Button
+  }}>{buttonText}</Button
 >
 
 <style>

--- a/src/lib/datasources/dataview/dataview.ts
+++ b/src/lib/datasources/dataview/dataview.ts
@@ -52,8 +52,8 @@ export class DataviewDataSource extends DataSource {
     return { fields, records };
   }
 
-  includes(_: string): boolean {
-    return true;
+  includes(path: string): boolean {
+    return !this.project.excludedNotes?.includes(path);
   }
 
   readonly(): boolean {

--- a/src/lib/datasources/frontmatter/frontmatter.ts
+++ b/src/lib/datasources/frontmatter/frontmatter.ts
@@ -49,6 +49,10 @@ export class FrontMatterDataSource extends DataSource {
   }
 
   includes(path: string): boolean {
+    if (this.project.excludedNotes?.includes(path)) {
+      return false;
+    }
+
     const trimmedPath = this.project.path.startsWith("/")
       ? this.project.path.slice(1)
       : this.project.path;

--- a/src/lib/stores/i18n.ts
+++ b/src/lib/stores/i18n.ts
@@ -88,6 +88,11 @@ i18next.init({
               description:
                 "Templates to choose from when you create new notes.",
             },
+            exclude: {
+              name: "Excluded notes",
+              description:
+                "Notes to exclude even if they would otherwise be part of the project.",
+            },
             defaultName: {
               name: "Default name",
               description:

--- a/src/modals/components/CreateProject.svelte
+++ b/src/modals/components/CreateProject.svelte
@@ -164,8 +164,22 @@
       vertical
     >
       <FileListInput
+        buttonText="Add template"
         paths={project.templates ?? []}
         onPathsChange={(templates) => (project = { ...project, templates })}
+      />
+    </SettingItem>
+
+    <SettingItem
+      name={$i18n.t("modals.project.exclude.name")}
+      description={$i18n.t("modals.project.exclude.description") ?? ""}
+      vertical
+    >
+      <FileListInput
+        buttonText="Add note"
+        paths={project.excludedNotes ?? []}
+        onPathsChange={(excludedNotes) =>
+          (project = { ...project, excludedNotes })}
       />
     </SettingItem>
   </ModalContent>

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface WorkspaceDefinitionV0 {
   readonly templates?: string[];
   readonly dataview?: boolean;
   readonly query?: string;
+  readonly excludedNotes?: string[];
 }
 
 export interface ProjectDefinition extends WorkspaceDefinitionV0 {}


### PR DESCRIPTION
This PR adds an option in the project settings to exclude notes from a project. 

Some folders may contain configuration files that aren't really part of the project. This lets you ignore them.