### PR TITLE
Add settings tab for setting quote preference

### DIFF
--- a/src/lib/data-api.ts
+++ b/src/lib/data-api.ts
@@ -138,7 +138,9 @@ export function doUpdateRecord(
           )
       );
     }),
-    E.chain((updated) => encodeFrontMatter(data, updated))
+    E.chain((updated) =>
+      encodeFrontMatter(data, updated, getDefaultStringType())
+    )
   );
 }
 
@@ -150,7 +152,9 @@ export function doDeleteField(data: string, field: string) {
       ...frontmatter,
       [field]: undefined,
     })),
-    E.chain((frontmatter) => encodeFrontMatter(data, frontmatter))
+    E.chain((frontmatter) =>
+      encodeFrontMatter(data, frontmatter, getDefaultStringType())
+    )
   );
 }
 
@@ -167,7 +171,9 @@ export function doRenameField(
       [to]: frontmatter[from],
       [from]: undefined,
     })),
-    E.chain((frontmatter) => encodeFrontMatter(data, frontmatter))
+    E.chain((frontmatter) =>
+      encodeFrontMatter(data, frontmatter, getDefaultStringType())
+    )
   );
 }
 
@@ -202,4 +208,8 @@ export function createDataRecord(
     id: normalizePath(project.path + "/" + name + ".md"),
     values: values ?? {},
   };
+}
+
+function getDefaultStringType() {
+  return get(settings).preferences?.frontmatter?.quoteStrings ?? "PLAIN";
 }

--- a/src/lib/metadata/encode.test.ts
+++ b/src/lib/metadata/encode.test.ts
@@ -5,19 +5,23 @@ import { encodeFrontMatter, stringifyYaml } from "./encode";
 describe("encodeFrontMatter", () => {
   it("should quote string if it contains illegal characters", () => {
     expect(
-      encodeFrontMatter(``, {
-        title1: "Notes: Who Needs Them?",
-        title2: "key:value",
-        title3: "key:",
-        title4: "- Title",
-        title5: "Title-",
-        title6: "-Title",
-      })
+      encodeFrontMatter(
+        ``,
+        {
+          title1: "Notes: Who Needs Them?",
+          title2: "key:value",
+          title3: "key:",
+          title4: "- Title",
+          title5: "Title-",
+          title6: "-Title",
+        },
+        "PLAIN"
+      )
     ).toStrictEqual(
       E.right(`---
 title1: "Notes: Who Needs Them?"
 title2: key:value
-title3: key:
+title3: "key:"
 title4: "- Title"
 title5: Title-
 title6: -Title
@@ -39,7 +43,8 @@ status: In progress
 `,
         {
           status: "Done",
-        }
+        },
+        "PLAIN"
       )
     ).toStrictEqual(
       E.right(`
@@ -65,7 +70,8 @@ due: 1979-01-01
 `,
         {
           status: "Done",
-        }
+        },
+        "PLAIN"
       )
     ).toStrictEqual(
       E.right(`
@@ -81,9 +87,13 @@ due: 1979-01-01
 
   it("should keep existing properties", () => {
     expect(
-      encodeFrontMatter(``, {
-        status: null,
-      })
+      encodeFrontMatter(
+        ``,
+        {
+          status: null,
+        },
+        "PLAIN"
+      )
     ).toStrictEqual(
       E.right(`---
 status:
@@ -110,12 +120,13 @@ test: 4
           foo: "5",
           bar: undefined,
           baz: null,
-        }
+        },
+        "PLAIN"
       )
     ).toStrictEqual(
       E.right(`
 ---
-foo: 5
+foo: "5"
 baz:
 test: 4
 ---
@@ -130,7 +141,7 @@ describe("stringifyYaml", () => {
   it("should strip quotes from string types", () => {
     expect(
       stringifyYaml({ bar: "Hello world", foo: "[[Untitled.md]]" })
-    ).toStrictEqual("bar: Hello world\nfoo: [[Untitled.md]]\n");
+    ).toStrictEqual('bar: Hello world\nfoo: "[[Untitled.md]]"\n');
   });
 
   it("should encode non-string types", () => {

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from "uuid";
 import { notEmpty } from "src/lib/helpers";
 import {
   DEFAULT_SETTINGS,
+  type ProjectsPluginPreferences,
   type ProjectsPluginSettings,
   type ProjectsPluginSettingsV1,
 } from "src/main";
@@ -38,6 +39,14 @@ function createSettings() {
             }));
           }
           draft.projects.push(project);
+        })
+      );
+    },
+
+    updatePreferences(prefs: ProjectsPluginPreferences) {
+      update((state) =>
+        produce(state, (draft) => {
+          draft.preferences = prefs;
         })
       );
     },

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import { CreateProjectModal } from "src/modals/create-project-modal";
 import { registerFileEvents } from "./events";
 import type { ProjectDefinition, WorkspaceDefinitionV0 } from "./types";
 import { ProjectsView, VIEW_TYPE_PROJECTS } from "./view";
+import { ProjectsSettingTab } from "./settings";
 
 dayjs.extend(isoWeek);
 dayjs.extend(localizedFormat);
@@ -25,11 +26,19 @@ export interface ProjectsPluginSettings {
   readonly lastViewId?: string | undefined;
   readonly workspaces: WorkspaceDefinitionV0[];
 }
+
+export interface ProjectsPluginPreferences {
+  readonly frontmatter?: {
+    readonly quoteStrings?: "PLAIN" | "QUOTE_DOUBLE";
+  };
+}
+
 export interface ProjectsPluginSettingsV1 {
   readonly version: number;
   readonly lastProjectId?: string | undefined;
   readonly lastViewId?: string | undefined;
   readonly projects: ProjectDefinition[];
+  readonly preferences?: ProjectsPluginPreferences;
 }
 
 export const DEFAULT_SETTINGS: Partial<ProjectsPluginSettingsV1> = {
@@ -41,6 +50,8 @@ export default class ProjectsPlugin extends Plugin {
 
   async onload() {
     const t = get(i18n).t;
+
+    this.addSettingTab(new ProjectsSettingTab(this.app, this));
 
     this.registerView(
       VIEW_TYPE_PROJECTS,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,41 @@
+import { App, PluginSettingTab, Setting } from "obsidian";
+import type { ProjectsPluginPreferences } from "./main";
+import type ProjectsPlugin from "./main";
+import { get } from "svelte/store";
+import { settings } from "src/lib/stores/settings";
+
+export class ProjectsSettingTab extends PluginSettingTab {
+  constructor(app: App, readonly plugin: ProjectsPlugin) {
+    super(app, plugin);
+  }
+
+  display(): void {
+    const { preferences } = get(settings);
+
+    const save = (prefs: ProjectsPluginPreferences) => {
+      settings.updatePreferences(prefs);
+    };
+    const { containerEl } = this;
+
+    containerEl.empty();
+
+    new Setting(containerEl).setName("Front matter").setHeading();
+
+    new Setting(containerEl).setName("Quote strings").addDropdown((dropdown) =>
+      dropdown
+        .addOption("PLAIN", "If needed")
+        .addOption("QUOTE_DOUBLE", "Always")
+        .setValue(preferences?.frontmatter?.quoteStrings ?? "PLAIN")
+        .onChange((value) => {
+          if (value === "PLAIN" || value === "QUOTE_DOUBLE") {
+            save({
+              ...preferences,
+              frontmatter: {
+                quoteStrings: value,
+              },
+            });
+          }
+        })
+    );
+  }
+}


### PR DESCRIPTION
Adds a settings tab with the option to always quote string values, or only when needed.

## Breaking change

This PR adds double quotes to internal links in front matter to follow Dataview and recommendations from Obsidian team.

Fixes #186 

