### PR TITLE
Disable on mobile devices

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,5 +7,5 @@
   "author": "Marcus Olsson",
   "authorUrl": "https://marcus.se.net",
   "fundingUrl": "https://www.buymeacoffee.com/marcusolsson",
-  "isDesktopOnly": false
+  "isDesktopOnly": true
 }


### PR DESCRIPTION
Unfortunately, after having allowed the plugin to be installed on mobile devices, it's become clear that more work is needed to make it work on mobile. Since the plugin can't even be installed on mobile devices, I've decided that I'll disable it for the time being to avoid unnecessary frustration.