### PR TITLE
Add options to text fields

### DIFF
--- a/obsidian-projects-types/index.ts
+++ b/obsidian-projects-types/index.ts
@@ -84,7 +84,7 @@ export class ViewApi {
   addRecord(record: DataRecord, templatePath: string): void {}
   updateRecord(record: DataRecord, fields: DataField[]): void {}
   deleteRecord(recordId: string): void {}
-  renameField(from: string, to: string): void {}
+  updateField(field: DataField): void {}
   deleteField(field: string): void {}
 }
 export interface ProjectDefinition {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jest": "^28.1.3",
     "obsidian": "latest",
     "obsidian-dataview": "^0.5.46",
-    "obsidian-svelte": "0.0.38",
+    "obsidian-svelte": "0.0.39",
     "prettier": "2.7.1",
     "prettier-plugin-svelte": "^2.8.0",
     "sortablejs": "^1.15.0",

--- a/src/app/onboarding/demo-project.ts
+++ b/src/app/onboarding/demo-project.ts
@@ -101,7 +101,7 @@ export async function createDemoProject(vault: Vault) {
     id: uuidv4(),
     path: demoFolder,
     recursive: false,
-    fields: {},
+    fieldConfig: {},
     views: [
       { name: "Table", id: uuidv4(), type: "table", config: tableConfig },
       { name: "Board", id: uuidv4(), type: "board", config: boardConfig },

--- a/src/app/onboarding/demo-project.ts
+++ b/src/app/onboarding/demo-project.ts
@@ -101,6 +101,7 @@ export async function createDemoProject(vault: Vault) {
     id: uuidv4(),
     path: demoFolder,
     recursive: false,
+    fields: {},
     views: [
       { name: "Table", id: uuidv4(), type: "table", config: tableConfig },
       { name: "Board", id: uuidv4(), type: "board", config: boardConfig },

--- a/src/components/FieldControl/FieldControl.svelte
+++ b/src/components/FieldControl/FieldControl.svelte
@@ -26,12 +26,11 @@
   export let onChange: (value: Optional<DataValue>) => void;
   export let readonly: boolean = false;
 
-  $: options = ((field.typeConfig?.["options"] ?? []) as string[]).map(
-    (option) => ({
+  $: options =
+    field.typeConfig?.options?.map((option) => ({
       label: option,
       description: "",
-    })
-  );
+    })) ?? [];
 </script>
 
 {#if field.type === DataFieldType.Boolean}

--- a/src/components/FieldControl/FieldControl.svelte
+++ b/src/components/FieldControl/FieldControl.svelte
@@ -26,7 +26,7 @@
   export let onChange: (value: Optional<DataValue>) => void;
   export let readonly: boolean = false;
 
-  $: options = ((field.userConfig?.["options"] ?? []) as string[]).map(
+  $: options = ((field.typeConfig?.["options"] ?? []) as string[]).map(
     (option) => ({
       label: option,
       description: "",

--- a/src/components/FieldControl/FieldControl.svelte
+++ b/src/components/FieldControl/FieldControl.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { DateInput, NumberInput, Switch, TextInput } from "obsidian-svelte";
+  import {
+    Autocomplete,
+    DateInput,
+    NumberInput,
+    Switch,
+    TextInput,
+  } from "obsidian-svelte";
 
   import { TagList } from "src/components/TagList";
   import {
@@ -19,6 +25,13 @@
   export let value: Optional<DataValue>;
   export let onChange: (value: Optional<DataValue>) => void;
   export let readonly: boolean = false;
+
+  $: options = ((field.userConfig?.["options"] ?? []) as string[]).map(
+    (option) => ({
+      label: option,
+      description: "",
+    })
+  );
 </script>
 
 {#if field.type === DataFieldType.Boolean}
@@ -29,11 +42,19 @@
 {:else if field.repeated && isOptionalList(value)}
   <TagList edit={true} values={value ?? []} {onChange} />
 {:else if field.type === DataFieldType.String}
-  <TextInput
-    value={isString(value) ? value : ""}
-    on:input={({ detail: value }) => onChange(value)}
-    {readonly}
-  />
+  {#if options.length > 0}
+    <Autocomplete
+      value={isString(value) ? value : ""}
+      {options}
+      on:change={({ detail }) => onChange(detail)}
+    />
+  {:else}
+    <TextInput
+      value={isString(value) ? value : ""}
+      on:input={({ detail: value }) => onChange(value)}
+      {readonly}
+    />
+  {/if}
 {:else if field.type === DataFieldType.Number}
   <NumberInput
     value={isNumber(value) ? value : null}

--- a/src/components/MultiTextInput/MultiTextInput.svelte
+++ b/src/components/MultiTextInput/MultiTextInput.svelte
@@ -41,7 +41,7 @@
 <div>
   {#each options as option, i}
     <span>
-      <TextInput value={option} on:blur={handleOptionChange(i)} />
+      <TextInput width="100%" value={option} on:blur={handleOptionChange(i)} />
       <IconButton icon="cross" on:click={handleOptionRemove(i)} />
     </span>
   {/each}
@@ -55,7 +55,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
-    align-items: flex-end;
+    width: 100%;
   }
   span {
     display: flex;

--- a/src/components/MultiTextInput/MultiTextInput.svelte
+++ b/src/components/MultiTextInput/MultiTextInput.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import produce from "immer";
+  import { Button, Icon, IconButton, TextInput } from "obsidian-svelte";
+
+  export let options: string[];
+  export let onChange: (options: string[]) => void;
+
+  function handleOptionAdd() {
+    onChange(
+      produce(options, (draft) => {
+        draft.push("");
+      })
+    );
+  }
+
+  function handleOptionRemove(i: number) {
+    return () => {
+      onChange(
+        produce(options, (draft) => {
+          draft.splice(i, 1);
+        })
+      );
+    };
+  }
+
+  function handleOptionChange(i: number) {
+    return (event: FocusEvent) => {
+      if (event.currentTarget instanceof HTMLInputElement) {
+        onChange(
+          produce(options, (draft) => {
+            if (event.currentTarget instanceof HTMLInputElement) {
+              draft.splice(i, 1, event.currentTarget.value);
+            }
+          })
+        );
+      }
+    };
+  }
+</script>
+
+<div>
+  {#each options as option, i}
+    <span>
+      <TextInput value={option} on:blur={handleOptionChange(i)} />
+      <IconButton icon="cross" on:click={handleOptionRemove(i)} />
+    </span>
+  {/each}
+  <Button variant="plain" on:click={handleOptionAdd}
+    ><Icon name="plus" />Add an option</Button
+  >
+</div>
+
+<style>
+  div {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    align-items: flex-end;
+  }
+  span {
+    display: flex;
+    gap: 4px;
+  }
+</style>

--- a/src/lib/data-api.ts
+++ b/src/lib/data-api.ts
@@ -188,6 +188,7 @@ export function createProject(): ProjectDefinition {
     recursive: false,
     defaultName: "",
     templates: [],
+    fields: {},
     views: [
       {
         id: uuidv4(),

--- a/src/lib/data-api.ts
+++ b/src/lib/data-api.ts
@@ -188,7 +188,7 @@ export function createProject(): ProjectDefinition {
     recursive: false,
     defaultName: "",
     templates: [],
-    fields: {},
+    fieldConfig: {},
     views: [
       {
         id: uuidv4(),

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,5 +1,5 @@
 import type { TFile } from "obsidian";
-import type { ProjectDefinition } from "src/types";
+import type { FieldConfig, ProjectDefinition } from "src/types";
 import type { RecordError } from "./datasources/frontmatter/frontmatter";
 
 /**
@@ -39,7 +39,7 @@ export interface DataField {
   /**
    * typeConfig defines user-defined field information.
    */
-  readonly typeConfig: Record<string, any>;
+  readonly typeConfig: FieldConfig;
 
   /**
    * repeated defines whether the field can have multiple values.

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -37,9 +37,9 @@ export interface DataField {
   readonly type: DataFieldType;
 
   /**
-   * userConfig defines user-defined field information.
+   * typeConfig defines user-defined field information.
    */
-  readonly userConfig: Record<string, any>;
+  readonly typeConfig: Record<string, any>;
 
   /**
    * repeated defines whether the field can have multiple values.

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -37,6 +37,11 @@ export interface DataField {
   readonly type: DataFieldType;
 
   /**
+   * userConfig defines user-defined field information.
+   */
+  readonly userConfig: Record<string, any>;
+
+  /**
    * repeated defines whether the field can have multiple values.
    */
   readonly repeated: boolean;
@@ -243,4 +248,8 @@ export function isStringLink(value: any): boolean {
     return /^\[\[(.*)\]\]$/.test(value);
   }
   return false;
+}
+
+export interface DataFieldSelectConfig {
+  options: string[];
 }

--- a/src/lib/datasources/frontmatter/frontmatter.ts
+++ b/src/lib/datasources/frontmatter/frontmatter.ts
@@ -41,13 +41,13 @@ export class FrontMatterDataSource extends DataSource {
 
     let fields = detectSchema(res.right);
 
-    for (const f in this.project.fields) {
+    for (const f in this.project.fieldConfig) {
       fields = fields.map<DataField>((field) =>
         field.name !== f
           ? field
           : {
               ...field,
-              typeConfig: this.project.fields[f] ?? {},
+              typeConfig: this.project.fieldConfig[f] ?? {},
             }
       );
     }

--- a/src/lib/datasources/frontmatter/frontmatter.ts
+++ b/src/lib/datasources/frontmatter/frontmatter.ts
@@ -47,7 +47,7 @@ export class FrontMatterDataSource extends DataSource {
           ? field
           : {
               ...field,
-              userConfig: this.project.fields[f] ?? {},
+              typeConfig: this.project.fields[f] ?? {},
             }
       );
     }

--- a/src/lib/datasources/frontmatter/frontmatter.ts
+++ b/src/lib/datasources/frontmatter/frontmatter.ts
@@ -41,6 +41,17 @@ export class FrontMatterDataSource extends DataSource {
 
     let fields = detectSchema(res.right);
 
+    for (const f in this.project.fields) {
+      fields = fields.map<DataField>((field) =>
+        field.name !== f
+          ? field
+          : {
+              ...field,
+              userConfig: this.project.fields[f] ?? {},
+            }
+      );
+    }
+
     for (const predefinedField of predefinedFields ?? []) {
       fields = fields.map((field) =>
         field.name !== predefinedField.name

--- a/src/lib/datasources/helpers.test.ts
+++ b/src/lib/datasources/helpers.test.ts
@@ -31,7 +31,7 @@ describe("parseRecords", () => {
         identifier: false,
         derived: false,
         repeated: false,
-        userConfig: {},
+        typeConfig: {},
       },
       {
         name: "text",
@@ -39,7 +39,7 @@ describe("parseRecords", () => {
         identifier: false,
         derived: false,
         repeated: false,
-        userConfig: {},
+        typeConfig: {},
       },
       {
         name: "boolean",
@@ -47,7 +47,7 @@ describe("parseRecords", () => {
         identifier: false,
         derived: false,
         repeated: false,
-        userConfig: {},
+        typeConfig: {},
       },
       {
         name: "repeated",
@@ -55,7 +55,7 @@ describe("parseRecords", () => {
         identifier: false,
         derived: false,
         repeated: true,
-        userConfig: {},
+        typeConfig: {},
       },
     ];
 
@@ -111,7 +111,7 @@ describe("detectFields", () => {
         identifier: false,
         derived: false,
         repeated: false,
-        userConfig: {},
+        typeConfig: {},
       },
       {
         name: "text",
@@ -119,7 +119,7 @@ describe("detectFields", () => {
         identifier: false,
         derived: false,
         repeated: false,
-        userConfig: {},
+        typeConfig: {},
       },
       {
         name: "boolean",
@@ -127,7 +127,7 @@ describe("detectFields", () => {
         identifier: false,
         derived: false,
         repeated: false,
-        userConfig: {},
+        typeConfig: {},
       },
       {
         name: "nullable",
@@ -135,7 +135,7 @@ describe("detectFields", () => {
         identifier: false,
         derived: false,
         repeated: false,
-        userConfig: {},
+        typeConfig: {},
       },
     ];
 

--- a/src/lib/datasources/helpers.test.ts
+++ b/src/lib/datasources/helpers.test.ts
@@ -31,6 +31,7 @@ describe("parseRecords", () => {
         identifier: false,
         derived: false,
         repeated: false,
+        userConfig: {},
       },
       {
         name: "text",
@@ -38,6 +39,7 @@ describe("parseRecords", () => {
         identifier: false,
         derived: false,
         repeated: false,
+        userConfig: {},
       },
       {
         name: "boolean",
@@ -45,6 +47,7 @@ describe("parseRecords", () => {
         identifier: false,
         derived: false,
         repeated: false,
+        userConfig: {},
       },
       {
         name: "repeated",
@@ -52,6 +55,7 @@ describe("parseRecords", () => {
         identifier: false,
         derived: false,
         repeated: true,
+        userConfig: {},
       },
     ];
 
@@ -107,6 +111,7 @@ describe("detectFields", () => {
         identifier: false,
         derived: false,
         repeated: false,
+        userConfig: {},
       },
       {
         name: "text",
@@ -114,6 +119,7 @@ describe("detectFields", () => {
         identifier: false,
         derived: false,
         repeated: false,
+        userConfig: {},
       },
       {
         name: "boolean",
@@ -121,6 +127,7 @@ describe("detectFields", () => {
         identifier: false,
         derived: false,
         repeated: false,
+        userConfig: {},
       },
       {
         name: "nullable",
@@ -128,6 +135,7 @@ describe("detectFields", () => {
         identifier: false,
         derived: false,
         repeated: false,
+        userConfig: {},
       },
     ];
 

--- a/src/lib/datasources/helpers.ts
+++ b/src/lib/datasources/helpers.ts
@@ -72,6 +72,7 @@ export function detectFields(records: DataRecord[]): DataField[] {
     identifier: false,
     derived: false,
     repeated: values.some(Array.isArray),
+    userConfig: {},
   }));
 }
 

--- a/src/lib/datasources/helpers.ts
+++ b/src/lib/datasources/helpers.ts
@@ -72,7 +72,7 @@ export function detectFields(records: DataRecord[]): DataField[] {
     identifier: false,
     derived: false,
     repeated: values.some(Array.isArray),
-    userConfig: {},
+    typeConfig: {},
   }));
 }
 

--- a/src/lib/stores/dataframe.ts
+++ b/src/lib/stores/dataframe.ts
@@ -78,8 +78,8 @@ function createDataFrame() {
       );
     },
     merge(updated: DataFrame) {
-      update((existing) => {
-        const res = produce(existing, (draft) => {
+      update((existing) =>
+        produce(existing, (draft) => {
           // Merge records.
           const recordSet = Object.fromEntries(
             existing.records.map((record) => [record.id, record])
@@ -127,10 +127,8 @@ function createDataFrame() {
 
           // Add new errors.
           draft.errors = [...draft.errors, ...(updated.errors ?? [])];
-        });
-
-        return res;
-      });
+        })
+      );
     },
   };
 }

--- a/src/lib/stores/dataframe.ts
+++ b/src/lib/stores/dataframe.ts
@@ -3,6 +3,7 @@ import { writable } from "svelte/store";
 
 import {
   DataFieldType,
+  type DataField,
   type DataFrame,
   type DataRecord,
   type DataSource,
@@ -48,16 +49,21 @@ function createDataFrame() {
         })
       );
     },
-    renameField(from: string, to: string) {
+    updateField(updated: DataField, oldName?: string) {
       update((state) =>
         produce(state, (draft) => {
-          draft.fields = draft.fields.map((field) =>
-            field.name === from
-              ? {
-                  ...field,
-                  name: to,
-                }
-              : field
+          draft.fields = draft.fields
+            .map((field) => (field.name === oldName ? updated : field))
+            .filter((field) => field.name !== oldName);
+
+          draft.records = draft.records.map((record) =>
+            produce(record, (draft) => {
+              if (oldName) {
+                // @ts-ignore
+                draft.values[updated.name] = draft.values[oldName];
+                delete draft.values[oldName];
+              }
+            })
           );
         })
       );
@@ -72,8 +78,8 @@ function createDataFrame() {
       );
     },
     merge(updated: DataFrame) {
-      update((existing) =>
-        produce(existing, (draft) => {
+      update((existing) => {
+        const res = produce(existing, (draft) => {
           // Merge records.
           const recordSet = Object.fromEntries(
             existing.records.map((record) => [record.id, record])
@@ -104,6 +110,13 @@ function createDataFrame() {
             }
           });
 
+          draft.fields = draft.fields.filter((field) =>
+            draft.records.some((record) => {
+              // @ts-ignore
+              return !!record.values[field.name];
+            })
+          );
+
           // Merge errors.
           const updatedIds = updated.records.map((record) => record.id);
 
@@ -114,8 +127,10 @@ function createDataFrame() {
 
           // Add new errors.
           draft.errors = [...draft.errors, ...(updated.errors ?? [])];
-        })
-      );
+        });
+
+        return res;
+      });
     },
   };
 }

--- a/src/lib/stores/i18n.ts
+++ b/src/lib/stores/i18n.ts
@@ -237,6 +237,7 @@ i18next.init({
         components: {
           "data-grid": {
             column: {
+              configure: "Configure field",
               rename: "Rename field",
               delete: "Delete field",
               hide: "Hide field",

--- a/src/lib/view-api.ts
+++ b/src/lib/view-api.ts
@@ -37,13 +37,16 @@ export class ViewApi {
     this.dataApi.deleteRecord(recordId);
   }
 
-  renameField(from: string, to: string) {
-    dataFrame.renameField(from, to);
-    this.dataApi.renameField(
-      filesFromRecords(this.app, get(dataFrame).records),
-      from,
-      to
-    );
+  updateField(field: DataField, oldName?: string) {
+    dataFrame.updateField(field, oldName);
+
+    if (oldName) {
+      this.dataApi.renameField(
+        filesFromRecords(this.app, get(dataFrame).records),
+        oldName,
+        field.name
+      );
+    }
   }
 
   deleteField(field: string) {

--- a/src/modals/components/ConfigureField.svelte
+++ b/src/modals/components/ConfigureField.svelte
@@ -29,10 +29,10 @@
     };
   }
 
-  function handleUserConfigChange(options: string[]) {
+  function handleTypeConfigChange(options: string[]) {
     field = {
       ...field,
-      userConfig: {
+      typeConfig: {
         options,
       },
     };
@@ -64,8 +64,8 @@
     {#if field.type === DataFieldType.String}
       <SettingItem name="Options" description="">
         <MultiTextInput
-          options={field.userConfig?.["options"] ?? []}
-          onChange={handleUserConfigChange}
+          options={field.typeConfig?.["options"] ?? []}
+          onChange={handleTypeConfigChange}
         />
       </SettingItem>
     {/if}

--- a/src/modals/components/ConfigureField.svelte
+++ b/src/modals/components/ConfigureField.svelte
@@ -68,7 +68,7 @@
         vertical
       >
         <MultiTextInput
-          options={field.typeConfig?.["options"] ?? []}
+          options={field.typeConfig?.options ?? []}
           onChange={handleTypeConfigChange}
         />
       </SettingItem>

--- a/src/modals/components/ConfigureField.svelte
+++ b/src/modals/components/ConfigureField.svelte
@@ -62,7 +62,11 @@
       />
     </SettingItem>
     {#if field.type === DataFieldType.String}
-      <SettingItem name="Options" description="">
+      <SettingItem
+        name="Options"
+        description="Predefined values for the field."
+        vertical
+      >
         <MultiTextInput
           options={field.typeConfig?.["options"] ?? []}
           onChange={handleTypeConfigChange}

--- a/src/modals/components/ConfigureField.svelte
+++ b/src/modals/components/ConfigureField.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import {
+    Button,
+    ModalButtonGroup,
+    ModalContent,
+    ModalLayout,
+    Select,
+    SettingItem,
+    TextInput,
+  } from "obsidian-svelte";
+  import MultiTextInput from "src/components/MultiTextInput/MultiTextInput.svelte";
+  import { DataFieldType, type DataField } from "src/lib/data";
+
+  export let title: string;
+  export let field: DataField;
+  export let onSave: (field: DataField) => void;
+
+  function handleNameChange(value: CustomEvent<string>) {
+    field = {
+      ...field,
+      name: value.detail,
+    };
+  }
+
+  function handleTypeChange(value: CustomEvent<string>) {
+    field = {
+      ...field,
+      type: value.detail as DataFieldType,
+    };
+  }
+
+  function handleUserConfigChange(options: string[]) {
+    field = {
+      ...field,
+      userConfig: {
+        options,
+      },
+    };
+  }
+
+  $: options = [
+    { label: "Text", value: DataFieldType.String },
+    { label: "Number", value: DataFieldType.Number },
+    { label: "Checkbox", value: DataFieldType.Boolean },
+    { label: "Date", value: DataFieldType.Date },
+    { label: "Link", value: DataFieldType.Link },
+    { label: "Unknown", value: DataFieldType.Unknown },
+  ];
+</script>
+
+<ModalLayout {title}>
+  <ModalContent>
+    <SettingItem name="Name">
+      <TextInput value={field.name} on:input={handleNameChange} />
+    </SettingItem>
+    <SettingItem name="Type">
+      <Select
+        disabled
+        value={field.type}
+        {options}
+        on:change={handleTypeChange}
+      />
+    </SettingItem>
+    {#if field.type === DataFieldType.String}
+      <SettingItem name="Options" description="">
+        <MultiTextInput
+          options={field.userConfig?.["options"] ?? []}
+          onChange={handleUserConfigChange}
+        />
+      </SettingItem>
+    {/if}
+  </ModalContent>
+  <ModalButtonGroup>
+    <Button
+      variant="primary"
+      on:click={() => {
+        onSave(field);
+      }}>Save</Button
+    >
+  </ModalButtonGroup>
+</ModalLayout>

--- a/src/modals/configure-field.ts
+++ b/src/modals/configure-field.ts
@@ -1,0 +1,37 @@
+import { App, Modal } from "obsidian";
+import type { DataField } from "src/lib/data";
+
+import ConfigureField from "./components/ConfigureField.svelte";
+
+export class ConfigureFieldModal extends Modal {
+  component?: ConfigureField;
+
+  constructor(
+    app: App,
+    readonly title: string,
+    readonly field: DataField,
+    readonly onSave: (field: DataField) => void
+  ) {
+    super(app);
+  }
+
+  onOpen() {
+    this.component = new ConfigureField({
+      target: this.contentEl,
+      props: {
+        title: this.title,
+        field: this.field,
+        onSave: (field: DataField) => {
+          this.onSave(field);
+          this.close();
+        },
+      },
+    });
+  }
+
+  onClose() {
+    if (this.component) {
+      this.component.$destroy();
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,7 @@ export interface WorkspaceDefinitionV0 {
   readonly id: string;
   readonly path: string;
   readonly recursive: boolean;
+  readonly fields: Record<string, Record<string, any>>;
   readonly views: ViewDefinition[];
   readonly defaultName?: string;
   readonly templates?: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,12 +83,18 @@ export interface FilterCondition {
   readonly value?: string;
 }
 
+export type StringFieldConfig = {
+  options?: string[];
+};
+
+export type FieldConfig = StringFieldConfig;
+
 export interface WorkspaceDefinitionV0 {
   readonly name: string;
   readonly id: string;
   readonly path: string;
   readonly recursive: boolean;
-  readonly fields: Record<string, Record<string, any>>;
+  readonly fieldConfig: { [field: string]: FieldConfig };
   readonly views: ViewDefinition[];
   readonly defaultName?: string;
   readonly templates?: string[];

--- a/src/views/Board/BoardView.svelte
+++ b/src/views/Board/BoardView.svelte
@@ -60,7 +60,35 @@
 
   $: groupedRecords = groupRecordsByField(records, groupByField?.name);
 
-  $: columns = Object.entries(groupedRecords).map((entry) => entry[0]);
+  function getColumns(records: Record<string, Array<DataRecord>>) {
+    const columns = new Set<string>(
+      Object.entries(records).map((entry) => entry[0])
+    );
+
+    if (groupByField?.type === DataFieldType.String) {
+      for (const option of groupByField?.userConfig?.["options"] ?? []) {
+        columns.add(option);
+      }
+    }
+
+    return [...columns]
+      .sort((a, b) => {
+        const aweight = config?.columns?.[a]?.weight ?? 0;
+        const bweight = config?.columns?.[b]?.weight ?? 0;
+
+        if (aweight < bweight) {
+          return -1;
+        } else if (aweight > bweight) {
+          return 1;
+        } else {
+          return 0;
+        }
+      })
+      .map((column) => ({
+        id: column,
+        records: groupedRecords[column] ?? [],
+      }));
+  }
 
   function handleRecordClick(record: DataRecord) {
     new EditNoteModal(
@@ -173,23 +201,7 @@
           });
         }}
         {readonly}
-        columns={columns
-          .sort((a, b) => {
-            const aweight = config?.columns?.[a]?.weight ?? 0;
-            const bweight = config?.columns?.[b]?.weight ?? 0;
-
-            if (aweight < bweight) {
-              return -1;
-            } else if (aweight > bweight) {
-              return 1;
-            } else {
-              return 0;
-            }
-          })
-          .map((column) => ({
-            id: column,
-            records: groupedRecords[column] ?? [],
-          }))}
+        columns={getColumns(groupedRecords)}
         groupByPriority={priorityField}
         onRecordClick={handleRecordClick}
         onRecordAdd={handleRecordAdd}

--- a/src/views/Board/BoardView.svelte
+++ b/src/views/Board/BoardView.svelte
@@ -66,7 +66,7 @@
     );
 
     if (groupByField?.type === DataFieldType.String) {
-      for (const option of groupByField?.typeConfig?.["options"] ?? []) {
+      for (const option of groupByField?.typeConfig?.options ?? []) {
         columns.add(option);
       }
     }

--- a/src/views/Board/BoardView.svelte
+++ b/src/views/Board/BoardView.svelte
@@ -66,7 +66,7 @@
     );
 
     if (groupByField?.type === DataFieldType.String) {
-      for (const option of groupByField?.userConfig?.["options"] ?? []) {
+      for (const option of groupByField?.typeConfig?.["options"] ?? []) {
         columns.add(option);
       }
     }

--- a/src/views/Board/components/Board/board-helpers.test.ts
+++ b/src/views/Board/components/Board/board-helpers.test.ts
@@ -37,7 +37,7 @@ describe("board", () => {
     repeated: false,
     derived: false,
     identifier: false,
-    userConfig: {},
+    typeConfig: {},
   };
   const dueField: DataField = {
     name: "due",
@@ -45,7 +45,7 @@ describe("board", () => {
     repeated: false,
     derived: false,
     identifier: false,
-    userConfig: {},
+    typeConfig: {},
   };
 
   it("should sort prioritized records", () => {

--- a/src/views/Board/components/Board/board-helpers.test.ts
+++ b/src/views/Board/components/Board/board-helpers.test.ts
@@ -37,6 +37,7 @@ describe("board", () => {
     repeated: false,
     derived: false,
     identifier: false,
+    userConfig: {},
   };
   const dueField: DataField = {
     name: "due",
@@ -44,6 +45,7 @@ describe("board", () => {
     repeated: false,
     derived: false,
     identifier: false,
+    userConfig: {},
   };
 
   it("should sort prioritized records", () => {

--- a/src/views/Table/TableView.svelte
+++ b/src/views/Table/TableView.svelte
@@ -6,7 +6,6 @@
   import type { ViewApi } from "src/lib/view-api";
   import { CreateNoteModal } from "src/modals/create-note-modal";
   import { EditNoteModal } from "src/modals/edit-note-modal";
-  import { InputDialogModal } from "src/modals/input-dialog";
   import type { ProjectDefinition } from "src/types";
 
   import type {
@@ -23,6 +22,8 @@
     ViewLayout,
     ViewToolbar,
   } from "src/components/Layout";
+  import { ConfigureFieldModal } from "src/modals/configure-field";
+  import { settings } from "src/lib/stores/settings";
 
   export let project: ProjectDefinition;
   export let frame: DataFrame;
@@ -47,12 +48,11 @@
     })
     .map<GridColDef>((field) => {
       const colDef: GridColDef = {
+        ...field,
         field: field.name,
-        type: field.type,
         width: fieldConfig[field.name]?.width ?? 180,
         hide: fieldConfig[field.name]?.hide ?? false,
         editable: !field.derived,
-        repeated: !!field.repeated,
       };
 
       const weight = defaultWeight(field.name);
@@ -159,16 +159,26 @@
       }}
       onRowDelete={(id) => api.deleteRecord(id)}
       onColumnHide={(column) => handleVisibilityChange(column.field, false)}
-      onColumnRename={(field) => {
-        new InputDialogModal(
-          $app,
-          $i18n.t("views.table.rename-field"),
-          $i18n.t("views.table.rename"),
-          (value) => {
-            api.renameField(field, value);
-          },
-          field
-        ).open();
+      onColumnConfigure={(column) => {
+        const field = fields.find((field) => field.name === column.field);
+
+        if (field) {
+          new ConfigureFieldModal($app, "Configure field", field, (field) => {
+            if (field.name !== column.field) {
+              api.updateField(field, column.field);
+            } else {
+              api.updateField(field);
+            }
+
+            settings.updateProject({
+              ...project,
+              fields: {
+                ...project.fields,
+                [field.name]: field.userConfig,
+              },
+            });
+          }).open();
+        }
       }}
       onColumnDelete={(field) => api.deleteField(field)}
       onRowChange={(rowId, row) => {

--- a/src/views/Table/TableView.svelte
+++ b/src/views/Table/TableView.svelte
@@ -169,12 +169,16 @@
             } else {
               api.updateField(field);
             }
-
+            const projectFields = Object.fromEntries(
+              Object.entries(project.fields).filter(([key, _]) =>
+                fields.find((field) => field.name === key)
+              )
+            );
             settings.updateProject({
               ...project,
               fields: {
-                ...project.fields,
-                [field.name]: field.userConfig,
+                ...projectFields,
+                [field.name]: field.typeConfig,
               },
             });
           }).open();

--- a/src/views/Table/TableView.svelte
+++ b/src/views/Table/TableView.svelte
@@ -170,13 +170,13 @@
               api.updateField(field);
             }
             const projectFields = Object.fromEntries(
-              Object.entries(project.fields).filter(([key, _]) =>
+              Object.entries(project.fieldConfig).filter(([key, _]) =>
                 fields.find((field) => field.name === key)
               )
             );
             settings.updateProject({
               ...project,
-              fields: {
+              fieldConfig: {
                 ...projectFields,
                 [field.name]: field.typeConfig,
               },

--- a/src/views/Table/components/DataGrid/DataGrid.svelte
+++ b/src/views/Table/components/DataGrid/DataGrid.svelte
@@ -33,7 +33,7 @@
   export let onRowAdd: () => void;
   export let onRowChange: (rowId: GridRowId, row: GridRowModel) => void;
   export let onRowNavigate: (rowId: GridRowId, openNew: boolean) => void;
-  export let onColumnRename: (field: string) => void;
+  export let onColumnConfigure: (column: GridColDef) => void;
   export let onColumnDelete: (field: string) => void;
   export let onColumnHide: (column: GridColDef) => void;
   export let onRowDelete: (rowId: GridRowId) => void;
@@ -54,9 +54,9 @@
     if (column.editable && !readonly) {
       menu.addItem((item) => {
         item
-          .setTitle(t("components.data-grid.column.rename"))
-          .setIcon("edit")
-          .onClick(() => onColumnRename(column.field));
+          .setTitle(t("components.data-grid.column.configure"))
+          .setIcon("settings")
+          .onClick(() => onColumnConfigure(column));
       });
       menu.addItem((item) => {
         item

--- a/src/views/Table/components/DataGrid/GridCell/GridCell.svelte
+++ b/src/views/Table/components/DataGrid/GridCell/GridCell.svelte
@@ -10,7 +10,7 @@
   export let resizable: boolean = false;
   export let onResize: (width: number) => void = () => {};
   export let onFinalizeResize: (width: number) => void = () => {};
-  export let column: GridColDef;
+  export let column: Partial<GridColDef>;
   export let rowindex: number;
   export let colindex: number;
   export let columnHeader: boolean = false;

--- a/src/views/Table/components/DataGrid/GridCell/GridTextCell/GridTextCell.svelte
+++ b/src/views/Table/components/DataGrid/GridCell/GridTextCell/GridTextCell.svelte
@@ -15,12 +15,11 @@
 
   let edit: boolean = false;
 
-  $: options = ((column.typeConfig?.["options"] ?? []) as string[]).map(
-    (option) => ({
+  $: options =
+    column.typeConfig?.options?.map((option) => ({
       label: option,
       description: "",
-    })
-  );
+    })) ?? [];
 </script>
 
 <GridCell

--- a/src/views/Table/components/DataGrid/GridCell/GridTextCell/GridTextCell.svelte
+++ b/src/views/Table/components/DataGrid/GridCell/GridTextCell/GridTextCell.svelte
@@ -2,7 +2,7 @@
   import { GridCell } from "..";
   import type { GridColDef } from "../../data-grid";
 
-  import { TextInput } from "obsidian-svelte";
+  import { Autocomplete, TextInput } from "obsidian-svelte";
   import TextLabel from "./TextLabel.svelte";
   import type { Optional } from "src/lib/data";
 
@@ -14,6 +14,13 @@
   export let selected: boolean;
 
   let edit: boolean = false;
+
+  $: options = ((column.userConfig?.["options"] ?? []) as string[]).map(
+    (option) => ({
+      label: option,
+      description: "",
+    })
+  );
 </script>
 
 <GridCell
@@ -36,24 +43,47 @@
   }}
 >
   <TextLabel slot="read" value={value || ""} />
-  <TextInput
-    autoFocus
-    slot="edit"
-    value={value || ""}
-    embed
-    width="100%"
-    on:input={({ detail }) => (value = detail)}
-    on:blur={(event) => {
-      if (
-        event.currentTarget instanceof HTMLInputElement &&
-        event.relatedTarget instanceof HTMLDivElement &&
-        !event.relatedTarget.contains(event.currentTarget)
-      ) {
-        selected = false;
-        edit = false;
-      }
+  <svelte:fragment slot="edit">
+    {#if options.length > 0}
+      <Autocomplete
+        value={value || ""}
+        {options}
+        embed
+        autoFocus
+        on:change={({ detail }) => (value = detail)}
+        on:blur={({ detail: event }) => {
+          if (
+            event.currentTarget instanceof HTMLInputElement &&
+            event.relatedTarget instanceof HTMLDivElement &&
+            !event.relatedTarget.contains(event.currentTarget)
+          ) {
+            selected = false;
+            edit = false;
+          }
 
-      onChange(value);
-    }}
-  />
+          onChange(value);
+        }}
+      />
+    {:else}
+      <TextInput
+        autoFocus
+        value={value || ""}
+        embed
+        width="100%"
+        on:input={({ detail }) => (value = detail)}
+        on:blur={(event) => {
+          if (
+            event.currentTarget instanceof HTMLInputElement &&
+            event.relatedTarget instanceof HTMLDivElement &&
+            !event.relatedTarget.contains(event.currentTarget)
+          ) {
+            selected = false;
+            edit = false;
+          }
+
+          onChange(value);
+        }}
+      />
+    {/if}
+  </svelte:fragment>
 </GridCell>

--- a/src/views/Table/components/DataGrid/GridCell/GridTextCell/GridTextCell.svelte
+++ b/src/views/Table/components/DataGrid/GridCell/GridTextCell/GridTextCell.svelte
@@ -15,7 +15,7 @@
 
   let edit: boolean = false;
 
-  $: options = ((column.userConfig?.["options"] ?? []) as string[]).map(
+  $: options = ((column.typeConfig?.["options"] ?? []) as string[]).map(
     (option) => ({
       label: option,
       description: "",

--- a/src/views/Table/components/DataGrid/GridRow.svelte
+++ b/src/views/Table/components/DataGrid/GridRow.svelte
@@ -106,6 +106,7 @@
       value={row[column.field]}
       {column}
       onChange={(value) => {
+        console.log({ value });
         onRowChange(
           rowId,
           produce(row, (draft) => {

--- a/src/views/Table/components/DataGrid/GridRow.svelte
+++ b/src/views/Table/components/DataGrid/GridRow.svelte
@@ -106,7 +106,6 @@
       value={row[column.field]}
       {column}
       onChange={(value) => {
-        console.log({ value });
         onRowChange(
           rowId,
           produce(row, (draft) => {

--- a/src/views/Table/components/DataGrid/data-grid.ts
+++ b/src/views/Table/components/DataGrid/data-grid.ts
@@ -1,20 +1,18 @@
 import type { Menu } from "obsidian";
 import { isDate } from "util/types";
-import { DataFieldType, isNumber } from "../../../../lib/data";
+import { DataFieldType, isNumber, type DataField } from "../../../../lib/data";
 
 export type GridValidRowModel = { [key: string]: any };
 export type GridRowModel<R extends GridValidRowModel = GridValidRowModel> = R;
 export type GridColType = DataFieldType;
 
-export interface GridColDef {
+export interface GridColDef extends DataField {
   readonly field: string;
   readonly width?: number;
-  readonly type?: GridColType;
   readonly hide?: boolean;
   readonly editable?: boolean;
   readonly header?: boolean;
   readonly weight?: number;
-  readonly repeated?: boolean;
 }
 
 export type GridRowId = string;
@@ -98,7 +96,7 @@ export function sortColumns(columns: GridColDef[]): GridColDef[] {
     } else if (left > right) {
       return 1;
     } else {
-      return 0;
+      return a.name.localeCompare(b.name);
     }
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3355,10 +3355,10 @@ obsidian-dataview@^0.5.46:
     parsimmon "^1.18.0"
     preact "^10.6.5"
 
-obsidian-svelte@0.0.38:
-  version "0.0.38"
-  resolved "https://registry.yarnpkg.com/obsidian-svelte/-/obsidian-svelte-0.0.38.tgz#9eddb3d3b6066518034bab8cf5c1e2b168cca53e"
-  integrity sha512-3ZshB9SQ69Ms1KeXszBQsZzgXMv3Mb83fyywgPhngktFFZcaOLohdU0Uxe/Mt2MKrBQ00/kaRrlZivMEXUkzcA==
+obsidian-svelte@0.0.39:
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/obsidian-svelte/-/obsidian-svelte-0.0.39.tgz#c0294de856a4f6b359b8f54c42af3971f217eb41"
+  integrity sha512-/DcCkSWS+ZiDzfih9dCvBZu45OaESlM6120pUz3BkAGjWbqv5mDOPIAHBvcLb1hJmw5BfcFxWG+a8DOuSdjEyg==
 
 obsidian@latest:
   version "0.16.3"


### PR DESCRIPTION
This PR adds a Configure field modal which allows the user to add options to text fields.

Options allow the user to autocomplete text fields in the table view and in the Edit record modal.

Options also allow for empty columns in the Board view.

<img width="509" alt="CleanShot 2022-12-28 at 23 43 28@2x" src="https://user-images.githubusercontent.com/8396880/209881874-952d5b8e-1fe6-45b6-b9af-0f551004bace.png">
<img width="590" alt="CleanShot 2022-12-28 at 23 43 48@2x" src="https://user-images.githubusercontent.com/8396880/209881875-118d7e9c-5644-49b1-8079-8b6dab03ddfc.png">
<img width="1386" alt="CleanShot 2022-12-28 at 23 43 56@2x" src="https://user-images.githubusercontent.com/8396880/209881876-4754dcfc-779e-4500-b2b8-1d67cd105862.png">


Fixes #221 