### PR TITLE
Add project size limit

### DIFF
--- a/src/lib/datasources/frontmatter/frontmatter.ts
+++ b/src/lib/datasources/frontmatter/frontmatter.ts
@@ -6,7 +6,11 @@ import {
   type DataFrame,
   type DataRecord,
 } from "src/lib/data";
-import { detectFields, parseRecords } from "src/lib/datasources/helpers";
+import {
+  detectFields,
+  parseRecords,
+  TooManyNotesError,
+} from "src/lib/datasources/helpers";
 import { notUndefined } from "src/lib/helpers";
 import { decodeFrontMatter } from "src/lib/metadata";
 import type { ProjectDefinition } from "src/types";
@@ -36,6 +40,13 @@ export class FrontMatterDataSource extends DataSource {
     const files = this.app.vault
       .getMarkdownFiles()
       .filter((file) => this.includes(file.path));
+
+    if (files.length > this.preferences.projectSizeLimit) {
+      throw new TooManyNotesError(
+        files.length,
+        this.preferences.projectSizeLimit
+      );
+    }
 
     return this.queryFiles(files);
   }

--- a/src/lib/datasources/helpers.ts
+++ b/src/lib/datasources/helpers.ts
@@ -148,3 +148,17 @@ function stringToBoolean(stringValue: string): boolean {
       return !!stringValue;
   }
 }
+
+export class TooManyNotesError extends Error {
+  constructor(n: number, limit: number) {
+    const message = `This project contains ${Intl.NumberFormat().format(
+      n
+    )} notes, which is more than the maximum project size (${Intl.NumberFormat().format(
+      limit
+    )}). You can increase the default limit in the plugin settings, but be aware that doing so may lead to a poor experience, or even cause the plugin to stop responding.`;
+
+    super(message);
+
+    this.name = "Too many notes";
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ dayjs.extend(isoWeek);
 dayjs.extend(localizedFormat);
 
 export type ProjectsPluginPreferences = {
+  readonly projectSizeLimit: number;
   readonly frontmatter: {
     readonly quoteStrings: "PLAIN" | "QUOTE_DOUBLE";
   };
@@ -41,6 +42,7 @@ export const DEFAULT_SETTINGS: ProjectsPluginSettings = {
   version: 1,
   projects: [],
   preferences: {
+    projectSizeLimit: 1000,
     frontmatter: {
       quoteStrings: "PLAIN",
     },

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,6 +19,21 @@ export class ProjectsSettingTab extends PluginSettingTab {
 
     containerEl.empty();
 
+    new Setting(containerEl)
+      .setName("Project size limit")
+      .setDesc("Avoid accidentally loading too many notes. Increasing ")
+      .addText((text) =>
+        text
+          .setValue(preferences.projectSizeLimit.toString())
+          .setPlaceholder("1000")
+          .onChange((value) => {
+            save({
+              ...preferences,
+              projectSizeLimit: parseInt(value) || 1000,
+            });
+          })
+      );
+
     new Setting(containerEl).setName("Front matter").setHeading();
 
     new Setting(containerEl).setName("Quote strings").addDropdown((dropdown) =>


### PR DESCRIPTION
This adds a safeguard for accidentally loading too many notes in a project. 

You can configure the project size limit from the plugin settings.