### PR TITLE
Add new Tag data source

### DIFF
--- a/obsidian-projects-types/index.ts
+++ b/obsidian-projects-types/index.ts
@@ -49,7 +49,6 @@ export enum DataFieldType {
   Number = "number",
   Boolean = "boolean",
   Date = "date",
-  Link = "link",
   Unknown = "unknown",
 }
 
@@ -63,7 +62,6 @@ export type DataValue =
   | number
   | boolean
   | Date
-  | Link
   | Array<Optional<DataValue>>;
 
 export type Optional<T> =
@@ -73,13 +71,6 @@ export type Optional<T> =
   // null means that while the field exists, it doesn't yet have a value.
   | null;
 
-export interface Link {
-  readonly displayName?: string;
-  readonly linkText: string;
-  readonly fullPath?: string;
-  readonly sourcePath: string;
-}
-
 export class ViewApi {
   addRecord(record: DataRecord, templatePath: string): void {}
   updateRecord(record: DataRecord, fields: DataField[]): void {}
@@ -87,16 +78,50 @@ export class ViewApi {
   updateField(field: DataField): void {}
   deleteField(field: string): void {}
 }
-export interface ProjectDefinition {
+
+export type StringFieldConfig = {
+  options?: string[];
+  richText?: boolean;
+};
+
+export type FieldConfig = StringFieldConfig;
+
+export type DataSource = FolderDataSource | TagDataSource | DataviewDataSource;
+
+export type FolderDataSource = {
+  readonly kind: "folder";
+  readonly config: {
+    readonly path: string;
+    readonly recursive: boolean;
+  };
+};
+
+export type TagDataSource = {
+  readonly kind: "tag";
+  readonly config: {
+    readonly tag: string;
+  };
+};
+
+export type DataviewDataSource = {
+  readonly kind: "dataview";
+  readonly config: {
+    readonly query: string;
+  };
+};
+
+export type ProjectDefinition = {
   readonly name: string;
   readonly id: string;
-  readonly path: string;
-  readonly recursive: boolean;
-  readonly defaultName?: string;
-  readonly templates?: string[];
-  readonly dataview?: boolean;
-  readonly query?: string;
-}
+
+  readonly fieldConfig: { [field: string]: FieldConfig };
+  readonly defaultName: string;
+  readonly templates: string[];
+  readonly excludedNotes: string[];
+  readonly isDefault: boolean;
+  readonly dataSource: DataSource;
+  readonly newNotesFolder: string;
+};
 
 export interface DataQueryResult {
   data: DataFrame;

--- a/obsidian-projects-types/index.ts
+++ b/obsidian-projects-types/index.ts
@@ -2,7 +2,7 @@
  * DataFrame is the core data structure that contains structured data for a
  * collection of notes.
  */
-export interface DataFrame {
+export type DataFrame = {
   /**
    * fields defines the schema for the data frame. Each field describes the
    * values in each DataRecord.
@@ -13,13 +13,13 @@ export interface DataFrame {
    * records holds the data from each note.
    */
   readonly records: DataRecord[];
-}
+};
 
 /**
  * DataField holds metadata for a value in DataRecord, for example a front
  * matter property.
  */
-export interface DataField {
+export type DataField = {
   /**
    * name references the a property (key) in the DataRecord values object.
    */
@@ -29,6 +29,11 @@ export interface DataField {
    * type defines the data type for the field.
    */
   readonly type: DataFieldType;
+
+  /**
+   * repeated defines whether the field can have multiple values.
+   */
+  readonly repeated: boolean;
 
   /**
    * identifier defines whether this field identifies a DataRecord.
@@ -42,7 +47,7 @@ export interface DataField {
    * modified.
    */
   readonly derived: boolean;
-}
+};
 
 export enum DataFieldType {
   String = "string",
@@ -52,10 +57,10 @@ export enum DataFieldType {
   Unknown = "unknown",
 }
 
-export interface DataRecord {
+export type DataRecord = {
   readonly id: string;
   readonly values: Record<string, Optional<DataValue>>;
-}
+};
 
 export type DataValue =
   | string
@@ -78,13 +83,6 @@ export class ViewApi {
   updateField(field: DataField): void {}
   deleteField(field: string): void {}
 }
-
-export type StringFieldConfig = {
-  options?: string[];
-  richText?: boolean;
-};
-
-export type FieldConfig = StringFieldConfig;
 
 export type DataSource = FolderDataSource | TagDataSource | DataviewDataSource;
 
@@ -113,8 +111,6 @@ export type DataviewDataSource = {
 export type ProjectDefinition = {
   readonly name: string;
   readonly id: string;
-
-  readonly fieldConfig: { [field: string]: FieldConfig };
   readonly defaultName: string;
   readonly templates: string[];
   readonly excludedNotes: string[];
@@ -123,9 +119,9 @@ export type ProjectDefinition = {
   readonly newNotesFolder: string;
 };
 
-export interface DataQueryResult {
+export type DataQueryResult = {
   data: DataFrame;
-}
+};
 
 export interface ProjectViewProps<T = Record<string, any>> {
   viewId: string;

--- a/obsidian-projects-types/package.json
+++ b/obsidian-projects-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-projects-types",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "types": "index.d.ts",
   "scripts": {
     "build": "tsc"

--- a/obsidian-projects-types/package.json
+++ b/obsidian-projects-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-projects-types",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "types": "index.d.ts",
   "scripts": {
     "build": "tsc"

--- a/src/app/AppContainer.svelte
+++ b/src/app/AppContainer.svelte
@@ -4,7 +4,8 @@
 
   import type { DataSource } from "src/lib/data";
   import { DataviewDataSource } from "src/lib/datasources/dataview/dataview";
-  import { FrontMatterDataSource } from "src/lib/datasources/frontmatter/frontmatter";
+  import { FolderDataSource } from "src/lib/datasources/folder/folder";
+  import { TagDataSource } from "src/lib/datasources/tag/tag";
   import { dataFrame, dataSource } from "src/lib/stores/dataframe";
   import { settings } from "src/lib/stores/settings";
   import { app } from "src/lib/stores/obsidian";
@@ -49,9 +50,14 @@
   // resolveDataSource selects the data source to use based on the project
   // settings.
   function resolveDataSource(project: ProjectDefinition, app: App): DataSource {
-    return project.dataview
-      ? new DataviewDataSource(app, project, $settings.preferences)
-      : new FrontMatterDataSource(app, project, $settings.preferences);
+    switch (project.dataSource.kind) {
+      case "folder":
+        return new FolderDataSource(app, project, $settings.preferences);
+      case "tag":
+        return new TagDataSource(app, project, $settings.preferences);
+      case "dataview":
+        return new DataviewDataSource(app, project, $settings.preferences);
+    }
   }
 
   const wait = () => new Promise((res) => setTimeout(res, 500));

--- a/src/app/AppContainer.svelte
+++ b/src/app/AppContainer.svelte
@@ -9,9 +9,9 @@
   import { dataFrame, dataSource } from "src/lib/stores/dataframe";
   import { settings } from "src/lib/stores/settings";
   import { app } from "src/lib/stores/obsidian";
-  import type { ProjectDefinition } from "src/types";
 
   import Toolbar from "./toolbar/Toolbar.svelte";
+  import type { ProjectDefinition } from "src/settings/settings";
 
   export let projects: ProjectDefinition[];
   export let projectId: string | undefined;
@@ -51,12 +51,12 @@
   // settings.
   function resolveDataSource(project: ProjectDefinition, app: App): DataSource {
     switch (project.dataSource.kind) {
-      case "folder":
-        return new FolderDataSource(app, project, $settings.preferences);
-      case "tag":
-        return new TagDataSource(app, project, $settings.preferences);
       case "dataview":
         return new DataviewDataSource(app, project, $settings.preferences);
+      case "tag":
+        return new TagDataSource(app, project, $settings.preferences);
+      default:
+        return new FolderDataSource(app, project, $settings.preferences);
     }
   }
 

--- a/src/app/View.svelte
+++ b/src/app/View.svelte
@@ -2,7 +2,10 @@
   import type { DataFrame, DataRecord } from "src/lib/data";
   import { settings } from "src/lib/stores/settings";
   import type { ViewApi } from "src/lib/view-api";
-  import type { ProjectDefinition, ViewDefinition } from "src/types";
+  import type {
+    ProjectDefinition,
+    ViewDefinition,
+  } from "src/settings/settings";
   import { applyFilter, matchesCondition } from "./filter-functions";
 
   import { useView } from "./useView";

--- a/src/app/filter-functions.ts
+++ b/src/app/filter-functions.ts
@@ -10,7 +10,7 @@ import {
   type FilterDefinition,
   type NumberFilterOperator,
   type StringFilterOperator,
-} from "src/types";
+} from "src/settings/settings";
 
 export function matchesCondition(
   cond: FilterCondition,

--- a/src/app/onboarding/demo-project.ts
+++ b/src/app/onboarding/demo-project.ts
@@ -7,7 +7,7 @@ import type { BoardConfig } from "src/views/Board/types";
 import type { CalendarConfig } from "src/views/Calendar/types";
 import type { GalleryConfig } from "src/views/Gallery/types";
 import type { TableConfig } from "src/views/Table/types";
-import { DEFAULT_PROJECT, DEFAULT_VIEW } from "src/types";
+import { DEFAULT_PROJECT, DEFAULT_VIEW } from "src/settings/settings";
 
 export async function createDemoProject(vault: Vault) {
   const demoFolder = "Projects - Demo Project";

--- a/src/app/onboarding/demo-project.ts
+++ b/src/app/onboarding/demo-project.ts
@@ -102,6 +102,13 @@ export async function createDemoProject(vault: Vault) {
       name: "Demo project",
       id: uuidv4(),
       path: demoFolder,
+      dataSource: {
+        kind: "folder",
+        config: {
+          path: demoFolder,
+          recursive: false,
+        },
+      },
       views: [
         Object.assign({}, DEFAULT_VIEW, {
           name: "Table",

--- a/src/app/toolbar/ProjectSelect.svelte
+++ b/src/app/toolbar/ProjectSelect.svelte
@@ -8,7 +8,7 @@
   import { settings } from "src/lib/stores/settings";
   import { ConfirmDialogModal } from "src/modals/confirm-dialog";
   import { CreateProjectModal } from "src/modals/create-project-modal";
-  import type { ProjectDefinition } from "src/types";
+  import type { ProjectDefinition } from "src/settings/settings";
 
   export let projectId: string | undefined;
   export let projects: ProjectDefinition[];

--- a/src/app/toolbar/Toolbar.svelte
+++ b/src/app/toolbar/Toolbar.svelte
@@ -15,13 +15,13 @@
   import { ConfirmDialogModal } from "src/modals/confirm-dialog";
   import { CreateNoteModal } from "src/modals/create-note-modal";
   import { CreateProjectModal } from "src/modals/create-project-modal";
-  import type { ProjectDefinition } from "src/types";
   import Flair from "./Flair.svelte";
 
   import ProjectSelect from "./ProjectSelect.svelte";
   import ViewSelect from "./ViewSelect.svelte";
   import { InspectorModal } from "src/modals/inspector";
   import produce from "immer";
+  import type { ProjectDefinition } from "src/settings/settings";
 
   export let projects: ProjectDefinition[];
 

--- a/src/app/toolbar/ViewSelect.svelte
+++ b/src/app/toolbar/ViewSelect.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { customViews } from "src/lib/stores/custom-views";
-  import type { ViewDefinition } from "src/types";
+  import type { ViewDefinition } from "src/settings/settings";
 
   import ViewItem from "./ViewItem.svelte";
   import ViewItemList from "./ViewItemList.svelte";

--- a/src/app/useView.ts
+++ b/src/app/useView.ts
@@ -3,8 +3,8 @@ import { get } from "svelte/store";
 import type { DataQueryResult } from "src/custom-view-api";
 import { customViews } from "src/lib/stores/custom-views";
 import type { ViewApi } from "src/lib/view-api";
-import type { ProjectDefinition, ViewDefinition } from "src/types";
 import type { DataRecord } from "src/lib/data";
+import type { ProjectDefinition, ViewDefinition } from "src/settings/settings";
 
 export interface ViewProps {
   view: ViewDefinition;

--- a/src/components/Accordion/AccordionItem.svelte
+++ b/src/components/Accordion/AccordionItem.svelte
@@ -35,8 +35,4 @@
     padding: 8px;
     justify-content: space-between;
   }
-
-  header:hover {
-    background-color: var(--background-modifier-hover);
-  }
 </style>

--- a/src/components/Accordion/index.ts
+++ b/src/components/Accordion/index.ts
@@ -1,0 +1,2 @@
+export { default as Accordion } from "./Accordion.svelte";
+export { default as AccordionItem } from "./AccordionItem.svelte";

--- a/src/components/FilterSettings/ColorFilterSettings.svelte
+++ b/src/components/FilterSettings/ColorFilterSettings.svelte
@@ -22,7 +22,7 @@
     type FilterOperator,
     type NumberFilterOperator,
     type StringFilterOperator,
-  } from "src/types";
+  } from "src/settings/settings";
 
   export let filter: ColorFilterDefinition;
   export let fields: DataField[];

--- a/src/components/FilterSettings/FilterSettings.svelte
+++ b/src/components/FilterSettings/FilterSettings.svelte
@@ -20,7 +20,7 @@
     type FilterOperator,
     type NumberFilterOperator,
     type StringFilterOperator,
-  } from "src/types";
+  } from "src/settings/settings";
 
   export let filter: FilterDefinition;
   export let fields: DataField[];

--- a/src/custom-view-api.ts
+++ b/src/custom-view-api.ts
@@ -1,6 +1,6 @@
 import type { DataFrame, DataRecord } from "src/lib/data";
 import type { ViewApi } from "src/lib/view-api";
-import type { ProjectDefinition } from "src/types";
+import type { ProjectDefinition } from "./settings/settings";
 
 export interface DataQueryResult {
   data: DataFrame;

--- a/src/lib/data-api.ts
+++ b/src/lib/data-api.ts
@@ -195,8 +195,18 @@ export function createDataRecord(
   project: ProjectDefinition,
   values?: Record<string, Optional<DataValue>>
 ): DataRecord {
+  let path = "";
+
+  if (project.dataSource.kind === "folder") {
+    path = project.dataSource.config.path;
+  }
+
+  if (project.newNotesFolder) {
+    path = project.newNotesFolder;
+  }
+
   return {
-    id: normalizePath(project.path + "/" + name + ".md"),
+    id: normalizePath(path + "/" + name + ".md"),
     values: values ?? {},
   };
 }

--- a/src/lib/data-api.ts
+++ b/src/lib/data-api.ts
@@ -6,12 +6,6 @@ import { get } from "svelte/store";
 import { v4 as uuidv4 } from "uuid";
 
 import {
-  DEFAULT_PROJECT,
-  DEFAULT_VIEW,
-  type ProjectDefinition,
-} from "src/types";
-
-import {
   isDate,
   type DataField,
   type DataRecord,
@@ -25,6 +19,11 @@ import { settings } from "./stores/settings";
 import { interpolateTemplate } from "./templates";
 
 import { function as F, task as T, either as E, taskEither as TE } from "fp-ts";
+import {
+  DEFAULT_PROJECT,
+  DEFAULT_VIEW,
+  type ProjectDefinition,
+} from "src/settings/settings";
 
 /**
  * DataApi writes records to file.

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,6 +1,9 @@
 import type { TFile } from "obsidian";
-import type { ProjectsPluginPreferences } from "src/main";
-import type { FieldConfig, ProjectDefinition } from "src/types";
+import type {
+  FieldConfig,
+  ProjectDefinition,
+  ProjectsPluginPreferences,
+} from "src/settings/settings";
 import type { RecordError } from "./datasources/frontmatter/frontmatter";
 
 /**

--- a/src/lib/datasources/dataview/dataview.ts
+++ b/src/lib/datasources/dataview/dataview.ts
@@ -2,6 +2,7 @@ import type { App } from "obsidian";
 import { DataviewApi, getAPI, isPluginEnabled, Link } from "obsidian-dataview";
 import { get } from "svelte/store";
 
+import produce from "immer";
 import type { TableResult } from "obsidian-dataview/lib/api/plugin-api";
 import {
   DataSource,
@@ -12,11 +13,11 @@ import {
 } from "src/lib/data";
 import { detectFields, parseRecords } from "src/lib/datasources/helpers";
 import { i18n } from "src/lib/stores/i18n";
-import type { ProjectDefinition } from "src/types";
-
+import type {
+  ProjectDefinition,
+  ProjectsPluginPreferences,
+} from "src/settings/settings";
 import { standardizeValues } from "./dataview-helpers";
-import produce from "immer";
-import type { ProjectsPluginPreferences } from "src/main";
 
 export class UnsupportedCapability extends Error {
   constructor(message: string) {

--- a/src/lib/datasources/dataview/dataview.ts
+++ b/src/lib/datasources/dataview/dataview.ts
@@ -5,6 +5,7 @@ import { get } from "svelte/store";
 import type { TableResult } from "obsidian-dataview/lib/api/plugin-api";
 import {
   DataSource,
+  emptyDataFrame,
   type DataField,
   type DataFrame,
   type DataRecord,
@@ -41,11 +42,19 @@ export class DataviewDataSource extends DataSource {
   }
 
   async queryAll(): Promise<DataFrame> {
+    if (this.project.dataSource.kind !== "dataview") {
+      return emptyDataFrame;
+    }
+
     const api = this.getDataviewAPI();
 
-    const result = await api?.query(this.project.query ?? "", undefined, {
-      forceId: true,
-    });
+    const result = await api?.query(
+      this.project.dataSource.config.query ?? "",
+      undefined,
+      {
+        forceId: true,
+      }
+    );
 
     if (!result?.successful || result.value.type !== "table") {
       throw new Error("dataview query failed");

--- a/src/lib/datasources/folder/folder.ts
+++ b/src/lib/datasources/folder/folder.ts
@@ -1,8 +1,9 @@
 import type { App } from "obsidian";
+import type {
+  ProjectDefinition,
+  ProjectsPluginPreferences,
+} from "src/settings/settings";
 
-import type { ProjectDefinition } from "src/types";
-
-import type { ProjectsPluginPreferences } from "src/main";
 import { FrontMatterDataSource } from "../frontmatter/frontmatter";
 
 export class FolderDataSource extends FrontMatterDataSource {

--- a/src/lib/datasources/folder/folder.ts
+++ b/src/lib/datasources/folder/folder.ts
@@ -1,0 +1,44 @@
+import type { App } from "obsidian";
+
+import type { ProjectDefinition } from "src/types";
+
+import type { ProjectsPluginPreferences } from "src/main";
+import { FrontMatterDataSource } from "../frontmatter/frontmatter";
+
+export class FolderDataSource extends FrontMatterDataSource {
+  constructor(
+    readonly app: App,
+    project: ProjectDefinition,
+    preferences: ProjectsPluginPreferences
+  ) {
+    super(app, project, preferences);
+  }
+
+  includes(path: string): boolean {
+    if (this.project.dataSource.kind !== "folder") {
+      return false;
+    }
+
+    if (this.project.excludedNotes?.includes(path)) {
+      return false;
+    }
+
+    const trimmedPath = this.project.dataSource.config.path.startsWith("/")
+      ? this.project.dataSource.config.path.slice(1)
+      : this.project.dataSource.config.path;
+
+    // No need to continue if file is not below the project path.
+    if (!path.startsWith(trimmedPath)) {
+      return false;
+    }
+
+    if (!this.project.dataSource.config.recursive) {
+      const pathElements = path.split("/").slice(0, -1);
+      const projectPathElements = trimmedPath.split("/").filter((el) => el);
+
+      return pathElements.join("/") === projectPathElements.join("/");
+    }
+
+    return true;
+  }
+}

--- a/src/lib/datasources/frontmatter/frontmatter.ts
+++ b/src/lib/datasources/frontmatter/frontmatter.ts
@@ -23,7 +23,7 @@ import type { ProjectsPluginPreferences } from "src/main";
 /**
  * FrontMatterDataSource converts Markdown front matter to DataFrames.
  */
-export class FrontMatterDataSource extends DataSource {
+export abstract class FrontMatterDataSource extends DataSource {
   constructor(
     readonly app: App,
     project: ProjectDefinition,
@@ -99,30 +99,6 @@ export class FrontMatterDataSource extends DataSource {
         return a.name.localeCompare(b.name);
       });
     });
-  }
-
-  includes(path: string): boolean {
-    if (this.project.excludedNotes?.includes(path)) {
-      return false;
-    }
-
-    const trimmedPath = this.project.path.startsWith("/")
-      ? this.project.path.slice(1)
-      : this.project.path;
-
-    // No need to continue if file is not below the project path.
-    if (!path.startsWith(trimmedPath)) {
-      return false;
-    }
-
-    if (!this.project.recursive) {
-      const pathElements = path.split("/").slice(0, -1);
-      const projectPathElements = trimmedPath.split("/").filter((el) => el);
-
-      return pathElements.join("/") === projectPathElements.join("/");
-    }
-
-    return true;
   }
 }
 

--- a/src/lib/datasources/frontmatter/frontmatter.ts
+++ b/src/lib/datasources/frontmatter/frontmatter.ts
@@ -13,12 +13,14 @@ import {
 } from "src/lib/datasources/helpers";
 import { notUndefined } from "src/lib/helpers";
 import { decodeFrontMatter } from "src/lib/metadata";
-import type { ProjectDefinition } from "src/types";
 
 import { array as A, either as E, function as F } from "fp-ts";
 import { standardizeRecord } from "./frontmatter-helpers";
 import produce from "immer";
-import type { ProjectsPluginPreferences } from "src/main";
+import type {
+  ProjectDefinition,
+  ProjectsPluginPreferences,
+} from "src/settings/settings";
 
 /**
  * FrontMatterDataSource converts Markdown front matter to DataFrames.

--- a/src/lib/datasources/tag/tag.ts
+++ b/src/lib/datasources/tag/tag.ts
@@ -1,0 +1,38 @@
+import { TFile, type App } from "obsidian";
+
+import type { ProjectDefinition } from "src/types";
+
+import type { ProjectsPluginPreferences } from "src/main";
+import { FrontMatterDataSource } from "../frontmatter/frontmatter";
+
+export class TagDataSource extends FrontMatterDataSource {
+  constructor(
+    readonly app: App,
+    project: ProjectDefinition,
+    preferences: ProjectsPluginPreferences
+  ) {
+    super(app, project, preferences);
+  }
+
+  includes(path: string): boolean {
+    if (this.project.dataSource.kind !== "tag") {
+      return false;
+    }
+
+    if (this.project.excludedNotes?.includes(path)) {
+      return false;
+    }
+
+    const { tag } = this.project.dataSource.config;
+
+    const file = this.app.vault.getAbstractFileByPath(path);
+
+    if (file instanceof TFile) {
+      const cache = this.app.metadataCache.getFileCache(file);
+
+      return cache?.tags?.map((tag) => tag.tag).includes(tag) ?? false;
+    }
+
+    return false;
+  }
+}

--- a/src/lib/datasources/tag/tag.ts
+++ b/src/lib/datasources/tag/tag.ts
@@ -1,8 +1,9 @@
 import { TFile, type App } from "obsidian";
+import type {
+  ProjectDefinition,
+  ProjectsPluginPreferences,
+} from "src/settings/settings";
 
-import type { ProjectDefinition } from "src/types";
-
-import type { ProjectsPluginPreferences } from "src/main";
 import { FrontMatterDataSource } from "../frontmatter/frontmatter";
 
 export class TagDataSource extends FrontMatterDataSource {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -2,7 +2,7 @@ import { normalizePath, TFile } from "obsidian";
 import { get } from "svelte/store";
 
 import { app } from "src/lib/stores/obsidian";
-import type { ProjectDefinition, ViewDefinition } from "src/types";
+import type { ProjectDefinition, ViewDefinition } from "src/settings/settings";
 
 /**
  * notEmpty is a convenience function for filtering arrays with optional values.

--- a/src/lib/stores/i18n.ts
+++ b/src/lib/stores/i18n.ts
@@ -70,6 +70,10 @@ i18next.init({
               description:
                 "Path to the folder you want to manage. Leave empty to use root folder.",
             },
+            tag: {
+              name: "Tag",
+              description: "Include all notes that have this tag.",
+            },
             dataview: {
               name: "Use Dataview",
               description:
@@ -99,10 +103,13 @@ i18next.init({
               description:
                 "Notes to exclude even if they would otherwise be part of the project.",
             },
+            newNotesFolder: {
+              name: "Location for new notes",
+              description: "Folder where all new notes are placed.",
+            },
             defaultName: {
-              name: "Default name",
-              description:
-                "Default name for new notes. Supports {{date}} and {{time}} template variables.",
+              name: "Default name for new notes",
+              description: "Supports {{date}} and {{time}} template variables.",
               invalid: "Contains illegal characters.",
             },
           },

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -5,18 +5,11 @@ import { v4 as uuidv4 } from "uuid";
 import { notEmpty } from "src/lib/helpers";
 import {
   DEFAULT_SETTINGS,
+  type ProjectDefinition,
   type ProjectsPluginPreferences,
   type ProjectsPluginSettings,
-} from "src/main";
-import {
-  DEFAULT_PROJECT,
-  DEFAULT_VIEW,
-  type ProjectDefinition,
-  type UnsavedProjectDefinition,
-  type UnsavedViewDefinition,
   type ViewDefinition,
-} from "src/types";
-import { either } from "fp-ts";
+} from "src/settings/settings";
 
 function createSettings() {
   const { set, update, subscribe } = writable<ProjectsPluginSettings>(
@@ -242,79 +235,3 @@ function createSettings() {
   };
 }
 export const settings = createSettings();
-
-/**
- * migrateSettings accepts the value from Plugin.loadData() and returns the most
- * recent settings. If needed, it applies any necessary migrations.
- */
-export function migrateSettings(
-  settings: any
-): either.Either<Error, ProjectsPluginSettings> {
-  if (!settings) {
-    return either.right(Object.assign({}, DEFAULT_SETTINGS));
-  }
-
-  if ("version" in settings && typeof settings.version === "number") {
-    // Apply defaults to any saved projects.
-    if ("projects" in settings && Array.isArray(settings.projects)) {
-      return either.tryCatch(() => {
-        return {
-          ...DEFAULT_SETTINGS,
-          ...settings,
-          projects: settings.projects.map(loadProject),
-          preferences: Object.assign({}, DEFAULT_SETTINGS.preferences),
-        };
-      }, either.toError);
-    }
-
-    return either.right({
-      ...DEFAULT_SETTINGS,
-      ...settings,
-    });
-  }
-
-  return either.left(new Error("Missing version"));
-}
-
-// loadProject returns a complete project definition, or throws an exception.
-function loadProject(project: Partial<ProjectDefinition>): ProjectDefinition {
-  const res: UnsavedProjectDefinition = {
-    ...DEFAULT_PROJECT,
-    ...project,
-  };
-
-  if ("name" in res && "id" in res) {
-    const { name, id } = res;
-
-    if (isString(name) && isString(id)) {
-      if ("views" in res && Array.isArray(res.views)) {
-        return { ...res, name, id, views: res.views.map(loadView) };
-      }
-      return { ...res, name, id, views: [] };
-    }
-  }
-
-  throw new Error("Invalid project definition");
-}
-
-// loadProject returns a complete view definition, or throws an exception.
-function loadView(view: Partial<ViewDefinition>): ViewDefinition {
-  const res: UnsavedViewDefinition = {
-    ...DEFAULT_VIEW,
-    ...view,
-  };
-
-  if ("name" in res && "id" in res && "type" in res) {
-    const { name, id, type } = res;
-
-    if (isString(name) && isString(id) && isString(type)) {
-      return { ...res, name, id, type };
-    }
-  }
-
-  throw new Error("Invalid view definition");
-}
-
-const isString = (value: unknown): value is string => {
-  return typeof value === "string";
-};

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,7 +79,13 @@ export default class ProjectsPlugin extends Plugin {
                   {
                     ...project,
                     name: file.name,
-                    path: file.path,
+                    dataSource: {
+                      kind: "folder",
+                      config: {
+                        path: file.path,
+                        recursive: false,
+                      },
+                    },
                   }
                 ).open();
               });

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,45 +9,17 @@ import { createDataRecord, createProject } from "src/lib/data-api";
 import { api } from "src/lib/stores/api";
 import { i18n } from "src/lib/stores/i18n";
 import { app, plugin } from "src/lib/stores/obsidian";
-import { migrateSettings, settings } from "src/lib/stores/settings";
+import { settings } from "src/lib/stores/settings";
 import { CreateNoteModal } from "src/modals/create-note-modal";
 import { CreateProjectModal } from "src/modals/create-project-modal";
 import { get, type Unsubscriber } from "svelte/store";
 import { registerFileEvents } from "./events";
 import { ProjectsSettingTab } from "./settings";
-import type { ProjectDefinition } from "./types";
+import { migrateSettings } from "./settings/settings";
 import { ProjectsView, VIEW_TYPE_PROJECTS } from "./view";
 
 dayjs.extend(isoWeek);
 dayjs.extend(localizedFormat);
-
-export type ProjectsPluginPreferences = {
-  readonly projectSizeLimit: number;
-  readonly frontmatter: {
-    readonly quoteStrings: "PLAIN" | "QUOTE_DOUBLE";
-  };
-};
-
-export type ProjectsPluginSettingsV1 = {
-  readonly version: 1;
-  readonly lastProjectId?: string | undefined;
-  readonly lastViewId?: string | undefined;
-  readonly projects: ProjectDefinition[];
-  readonly preferences: ProjectsPluginPreferences;
-};
-
-export type ProjectsPluginSettings = ProjectsPluginSettingsV1;
-
-export const DEFAULT_SETTINGS: ProjectsPluginSettings = {
-  version: 1,
-  projects: [],
-  preferences: {
-    projectSizeLimit: 1000,
-    frontmatter: {
-      quoteStrings: "PLAIN",
-    },
-  },
-};
 
 export default class ProjectsPlugin extends Plugin {
   unsubscribeSettings?: Unsubscriber;

--- a/src/modals/add-view-modal.ts
+++ b/src/modals/add-view-modal.ts
@@ -1,6 +1,5 @@
 import { App, Modal } from "obsidian";
-
-import type { ProjectDefinition, ViewDefinition } from "src/types";
+import type { ProjectDefinition, ViewDefinition } from "src/settings/settings";
 
 import AddView from "./components/AddView.svelte";
 

--- a/src/modals/components/AddView.svelte
+++ b/src/modals/components/AddView.svelte
@@ -19,7 +19,7 @@
     type ProjectDefinition,
     type ViewDefinition,
     type ViewType,
-  } from "src/types";
+  } from "src/settings/settings";
 
   export let onSave: (projectId: string, view: ViewDefinition) => void;
   export let project: ProjectDefinition;

--- a/src/modals/components/CreateNote.svelte
+++ b/src/modals/components/CreateNote.svelte
@@ -2,7 +2,6 @@
   import { normalizePath, TFile } from "obsidian";
   import {
     Button,
-    Callout,
     ModalButtonGroup,
     ModalContent,
     ModalLayout,
@@ -29,13 +28,25 @@
 
   $: nameError = validateName(name);
 
+  function getNewNotesFolder(project: ProjectDefinition) {
+    if (project.newNotesFolder) {
+      return project.newNotesFolder;
+    }
+
+    if (project.dataSource.kind === "folder") {
+      return project.dataSource.config.path;
+    }
+
+    return "";
+  }
+
   function validateName(name: string) {
     if (name === "") {
       return $i18n.t("modals.note.create.empty-name-error");
     }
 
     const existingFile = $app.vault.getAbstractFileByPath(
-      normalizePath(project.path + "/" + name + ".md")
+      normalizePath(getNewNotesFolder(project) + "/" + name + ".md")
     );
 
     if (existingFile instanceof TFile) {
@@ -102,22 +113,11 @@
         />
       </SettingItem>
     {/if}
-    {#if project.dataview}
-      <Callout
-        title={$i18n.t("modals.note.create.readonly.title")}
-        icon="alert-triangle"
-        variant="danger"
-      >
-        {$i18n.t("modals.note.create.readonly.message", {
-          project: project.name,
-        })}
-      </Callout>
-    {/if}
   </ModalContent>
   <ModalButtonGroup>
     <Button
       variant={"primary"}
-      disabled={!!nameError || !!project.dataview}
+      disabled={!!nameError}
       on:click={() => {
         onSave(name, templatePath, project);
       }}

--- a/src/modals/components/CreateNote.svelte
+++ b/src/modals/components/CreateNote.svelte
@@ -14,7 +14,7 @@
   import { i18n } from "src/lib/stores/i18n";
   import { app } from "src/lib/stores/obsidian";
   import { settings } from "src/lib/stores/settings";
-  import type { ProjectDefinition } from "src/types";
+  import type { ProjectDefinition } from "src/settings/settings";
 
   export let name: string;
   export let project: ProjectDefinition;

--- a/src/modals/components/CreateProject.svelte
+++ b/src/modals/components/CreateProject.svelte
@@ -7,6 +7,7 @@
     ModalButtonGroup,
     ModalContent,
     ModalLayout,
+    Select,
     SettingItem,
     Switch,
     TextArea,
@@ -14,6 +15,7 @@
   } from "obsidian-svelte";
 
   import { FileListInput } from "src/components/FileListInput";
+  import { Accordion, AccordionItem } from "src/components/Accordion";
   import { notEmpty } from "src/lib/helpers";
   import { getFoldersInFolder, isValidPath } from "src/lib/obsidian";
   import { capabilities } from "src/lib/stores/capabilities";
@@ -39,6 +41,41 @@
 
   $: ({ name } = project);
   $: nameError = validateName(name);
+
+  const dataSourceOptions = [
+    { label: "Folder", value: "folder" },
+    { label: "Tag", value: "tag" },
+  ];
+
+  if ($capabilities.dataview) {
+    dataSourceOptions.push({ label: "Dataview", value: "dataview" });
+  }
+
+  function handleDataSourceChange({ detail: value }: CustomEvent<string>) {
+    switch (value) {
+      case "folder":
+        project = {
+          ...project,
+          dataSource: {
+            kind: "folder",
+            config: { path: "", recursive: false },
+          },
+        };
+        break;
+      case "tag":
+        project = {
+          ...project,
+          dataSource: { kind: "tag", config: { tag: "" } },
+        };
+        break;
+      case "dataview":
+        project = {
+          ...project,
+          dataSource: { kind: "dataview", config: { query: "" } },
+        };
+        break;
+    }
+  }
 
   function validateName(name: string) {
     if (name === originalName) {
@@ -82,44 +119,18 @@
       />
     </SettingItem>
 
-    {#if project.dataview || $capabilities.dataview}
-      <SettingItem
-        name={$i18n.t("modals.project.dataview.name")}
-        description={$i18n.t("modals.project.dataview.description") ?? ""}
-      >
-        <Switch
-          checked={!!project.dataview}
-          on:check={({ detail: dataview }) =>
-            (project = { ...project, dataview })}
-        />
-      </SettingItem>
-    {/if}
+    <SettingItem
+      name="Data source"
+      description="Choose how you want to define which notes to include."
+    >
+      <Select
+        value={project.dataSource.kind}
+        options={dataSourceOptions}
+        on:change={handleDataSourceChange}
+      />
+    </SettingItem>
 
-    {#if project.dataview && !$capabilities.dataview}
-      <Callout
-        title={$i18n.t("modals.project.dataview.error.title")}
-        icon="zap"
-        variant="danger"
-      >
-        {$i18n.t("modals.project.dataview.error.message")}
-      </Callout>
-    {/if}
-
-    {#if project.dataview}
-      <SettingItem
-        name={$i18n.t("modals.project.query.name")}
-        description={$i18n.t("modals.project.query.description") ?? ""}
-        vertical
-      >
-        <TextArea
-          placeholder={`TABLE status AS "Status" FROM "Work"`}
-          value={project.query ?? ""}
-          on:input={({ detail: query }) => (project = { ...project, query })}
-          rows={6}
-          width="100%"
-        />
-      </SettingItem>
-    {:else}
+    {#if project.dataSource.kind === "folder"}
       <SettingItem
         name={$i18n.t("modals.project.path.name")}
         description={$i18n.t("modals.project.path.description") ?? ""}
@@ -127,8 +138,18 @@
       >
         <FileAutocomplete
           files={getFoldersInFolder($app.vault.getRoot())}
-          value={project.path}
-          on:change={({ detail: path }) => (project = { ...project, path })}
+          value={project.dataSource.config.path}
+          on:change={({ detail: path }) => {
+            if (project.dataSource.kind === "folder") {
+              project = {
+                ...project,
+                dataSource: {
+                  kind: project.dataSource.kind,
+                  config: { ...project.dataSource.config, path },
+                },
+              };
+            }
+          }}
           getLabel={(file) => file.path}
           width="100%"
         />
@@ -139,58 +160,156 @@
         description={$i18n.t("modals.project.recursive.description") ?? ""}
       >
         <Switch
-          checked={project.recursive}
-          on:check={({ detail: recursive }) =>
-            (project = { ...project, recursive })}
+          checked={project.dataSource.config.recursive}
+          on:check={({ detail: recursive }) => {
+            if (project.dataSource.kind === "folder") {
+              project = {
+                ...project,
+                dataSource: {
+                  kind: project.dataSource.kind,
+                  config: { ...project.dataSource.config, recursive },
+                },
+              };
+            }
+          }}
         />
       </SettingItem>
     {/if}
 
-    <SettingItem
-      name={$i18n.t("modals.project.defaultName.name")}
-      description={$i18n.t("modals.project.defaultName.description") ?? ""}
-      vertical
-    >
-      <TextInput
-        value={project.defaultName ?? ""}
-        on:input={({ detail: defaultName }) =>
-          (project = { ...project, defaultName })}
-        width="100%"
-      />
-      <small>
-        {defaultName}
-      </small>
-      {#if !isValidPath(defaultName)}
-        <small class="error"
-          >{$i18n.t("modals.project.defaultName.invalid")}</small
+    {#if project.dataSource.kind === "tag"}
+      <SettingItem
+        name={$i18n.t("modals.project.tag.name")}
+        description={$i18n.t("modals.project.tag.description") ?? ""}
+        vertical
+      >
+        <TextInput
+          placeholder="#tag"
+          value={project.dataSource.config.tag ?? ""}
+          on:input={({ detail: tag }) => {
+            if (project.dataSource.kind === "tag") {
+              project = {
+                ...project,
+                dataSource: {
+                  kind: project.dataSource.kind,
+                  config: { ...project.dataSource.config, tag },
+                },
+              };
+            }
+          }}
+          width="100%"
+        />
+      </SettingItem>
+    {/if}
+
+    {#if project.dataSource.kind === "dataview"}
+      {#if $capabilities.dataview}
+        <SettingItem
+          name={$i18n.t("modals.project.query.name")}
+          description={$i18n.t("modals.project.query.description") ?? ""}
+          vertical
         >
+          <TextArea
+            placeholder={`TABLE status AS "Status" FROM "Work"`}
+            value={project.dataSource.config.query ?? ""}
+            on:input={({ detail: query }) => {
+              if (project.dataSource.kind === "dataview") {
+                project = {
+                  ...project,
+                  dataSource: {
+                    kind: project.dataSource.kind,
+                    config: { ...project.dataSource.config, query },
+                  },
+                };
+              }
+            }}
+            rows={6}
+            width="100%"
+          />
+        </SettingItem>
+      {:else}
+        <Callout
+          title={$i18n.t("modals.project.dataview.error.title")}
+          icon="zap"
+          variant="danger"
+        >
+          {$i18n.t("modals.project.dataview.error.message")}
+        </Callout>
       {/if}
-    </SettingItem>
+    {/if}
 
-    <SettingItem
-      name={$i18n.t("modals.project.templates.name")}
-      description={$i18n.t("modals.project.templates.description") ?? ""}
-      vertical
-    >
-      <FileListInput
-        buttonText="Add template"
-        paths={project.templates ?? []}
-        onPathsChange={(templates) => (project = { ...project, templates })}
-      />
-    </SettingItem>
+    <Accordion>
+      <AccordionItem>
+        <div slot="header" class="setting-item-info" style:margin-top="8px">
+          <div class="setting-item-name">More settings</div>
+        </div>
+        <SettingItem
+          name={$i18n.t("modals.project.newNotesFolder.name")}
+          description={$i18n.t("modals.project.newNotesFolder.description") ??
+            ""}
+        >
+          <FileAutocomplete
+            files={getFoldersInFolder($app.vault.getRoot())}
+            value={project.newNotesFolder}
+            placeholder={project.dataSource.kind === "folder"
+              ? project.dataSource.config.path
+              : "/"}
+            on:change={({ detail: newNotesFolder }) => {
+              project = {
+                ...project,
+                newNotesFolder,
+              };
+            }}
+            getLabel={(file) => file.path}
+          />
+        </SettingItem>
 
-    <SettingItem
-      name={$i18n.t("modals.project.exclude.name")}
-      description={$i18n.t("modals.project.exclude.description") ?? ""}
-      vertical
-    >
-      <FileListInput
-        buttonText="Add note"
-        paths={project.excludedNotes ?? []}
-        onPathsChange={(excludedNotes) =>
-          (project = { ...project, excludedNotes })}
-      />
-    </SettingItem>
+        <SettingItem
+          name={$i18n.t("modals.project.defaultName.name")}
+          description={$i18n.t("modals.project.defaultName.description") ?? ""}
+          vertical
+        >
+          <TextInput
+            value={project.defaultName ?? ""}
+            on:input={({ detail: defaultName }) =>
+              (project = { ...project, defaultName })}
+            width="100%"
+          />
+          <small>
+            {defaultName}
+          </small>
+          {#if !isValidPath(defaultName)}
+            <small class="error"
+              >{$i18n.t("modals.project.defaultName.invalid")}</small
+            >
+          {/if}
+        </SettingItem>
+
+        <SettingItem
+          name={$i18n.t("modals.project.templates.name")}
+          description={$i18n.t("modals.project.templates.description") ?? ""}
+          vertical
+        >
+          <FileListInput
+            buttonText="Add template"
+            paths={project.templates ?? []}
+            onPathsChange={(templates) => (project = { ...project, templates })}
+          />
+        </SettingItem>
+
+        <SettingItem
+          name={$i18n.t("modals.project.exclude.name")}
+          description={$i18n.t("modals.project.exclude.description") ?? ""}
+          vertical
+        >
+          <FileListInput
+            buttonText="Add note"
+            paths={project.excludedNotes ?? []}
+            onPathsChange={(excludedNotes) =>
+              (project = { ...project, excludedNotes })}
+          />
+        </SettingItem>
+      </AccordionItem>
+    </Accordion>
   </ModalContent>
   <ModalButtonGroup>
     <Button

--- a/src/modals/components/CreateProject.svelte
+++ b/src/modals/components/CreateProject.svelte
@@ -23,7 +23,7 @@
   import { app } from "src/lib/stores/obsidian";
   import { settings } from "src/lib/stores/settings";
   import { interpolateTemplate } from "src/lib/templates";
-  import type { ProjectDefinition } from "src/types";
+  import type { ProjectDefinition } from "src/settings/settings";
 
   export let title: string;
   export let cta: string;

--- a/src/modals/create-note-modal.ts
+++ b/src/modals/create-note-modal.ts
@@ -34,7 +34,7 @@ export class CreateNoteModal extends Modal {
               time: (format) => moment().format(format || "HH:mm"),
             })
           : nextUniqueFileName(
-              this.project.path,
+              this.project.newNotesFolder,
               get(i18n).t("modals.note.create.untitled")
             ),
         project: this.project,

--- a/src/modals/create-note-modal.ts
+++ b/src/modals/create-note-modal.ts
@@ -5,9 +5,9 @@ import { get } from "svelte/store";
 import { nextUniqueFileName } from "src/lib/helpers";
 import { i18n } from "src/lib/stores/i18n";
 import { interpolateTemplate } from "src/lib/templates";
-import type { ProjectDefinition } from "src/types";
 
 import CreateNote from "./components/CreateNote.svelte";
+import type { ProjectDefinition } from "src/settings/settings";
 
 export class CreateNoteModal extends Modal {
   component?: CreateNote;

--- a/src/modals/create-project-modal.ts
+++ b/src/modals/create-project-modal.ts
@@ -1,6 +1,5 @@
 import { App, Modal } from "obsidian";
-
-import type { ProjectDefinition } from "src/types";
+import type { ProjectDefinition } from "src/settings/settings";
 
 import CreateProject from "./components/CreateProject.svelte";
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,7 +2,7 @@ import { App, PluginSettingTab, Setting } from "obsidian";
 import { settings } from "src/lib/stores/settings";
 import { get } from "svelte/store";
 import type ProjectsPlugin from "./main";
-import type { ProjectsPluginPreferences } from "./main";
+import type { ProjectsPluginPreferences } from "./settings/settings";
 
 export class ProjectsSettingTab extends PluginSettingTab {
   constructor(app: App, readonly plugin: ProjectsPlugin) {
@@ -15,6 +15,7 @@ export class ProjectsSettingTab extends PluginSettingTab {
     const save = (prefs: ProjectsPluginPreferences) => {
       settings.updatePreferences(prefs);
     };
+
     const { containerEl } = this;
 
     containerEl.empty();

--- a/src/settings/base/settings.ts
+++ b/src/settings/base/settings.ts
@@ -1,0 +1,98 @@
+export type ViewType = string;
+
+export interface ViewDefinition {
+  readonly name: string;
+  readonly id: string;
+  readonly type: ViewType;
+  readonly config: Record<string, any>;
+  readonly filter: FilterDefinition;
+  readonly colors: ColorFilterDefinition;
+}
+
+export interface FilterDefinition {
+  readonly conditions: FilterCondition[];
+}
+
+export interface ColorFilterDefinition {
+  readonly conditions: ColorRule[];
+}
+
+export interface ColorRule {
+  color: string;
+  condition: FilterCondition;
+}
+
+export type BaseFilterOperator = "is-empty" | "is-not-empty";
+
+export type StringFilterOperator =
+  | "is"
+  | "is-not"
+  | "contains"
+  | "not-contains";
+
+export function isStringFilterOperator(
+  op: FilterOperator
+): op is StringFilterOperator {
+  return ["is", "is-not", "contains", "not-contains"].includes(op);
+}
+
+export type NumberFilterOperator = "eq" | "neq" | "lt" | "gt" | "lte" | "gte";
+
+export function isNumberFilterOperator(
+  op: FilterOperator
+): op is NumberFilterOperator {
+  return ["eq", "neq", "lt", "gt", "lte", "gte"].includes(op);
+}
+
+export type BooleanFilterOperator = "is-checked" | "is-not-checked";
+
+export function isBooleanFilterOperator(
+  op: FilterOperator
+): op is BooleanFilterOperator {
+  return ["is-checked", "is-not-checked"].includes(op);
+}
+
+export type FilterOperator =
+  | BaseFilterOperator
+  | StringFilterOperator
+  | NumberFilterOperator
+  | BooleanFilterOperator;
+
+export type FilterOperatorType = "unary" | "binary";
+
+export const filterOperatorTypes: Record<FilterOperator, FilterOperatorType> = {
+  "is-empty": "unary",
+  "is-not-empty": "unary",
+  is: "binary",
+  "is-not": "binary",
+  contains: "binary",
+  "not-contains": "binary",
+  eq: "binary",
+  neq: "binary",
+  lt: "binary",
+  gt: "binary",
+  lte: "binary",
+  gte: "binary",
+  "is-checked": "unary",
+  "is-not-checked": "unary",
+};
+
+export interface FilterCondition {
+  readonly field: string;
+  readonly operator: FilterOperator;
+  readonly value?: string;
+}
+
+export type StringFieldConfig = {
+  options?: string[];
+  richText?: boolean;
+};
+
+export type FieldConfig = StringFieldConfig;
+
+export type ProjectsPluginPreferences = {
+  readonly projectSizeLimit: number;
+  readonly frontmatter: {
+    readonly quoteStrings: "PLAIN" | "QUOTE_DOUBLE";
+  };
+};

--- a/src/settings/base/settings.ts
+++ b/src/settings/base/settings.ts
@@ -96,3 +96,14 @@ export type ProjectsPluginPreferences = {
     readonly quoteStrings: "PLAIN" | "QUOTE_DOUBLE";
   };
 };
+
+export type UnsavedViewDefinition = Omit<
+  ViewDefinition,
+  "name" | "id" | "type"
+>;
+
+export const DEFAULT_VIEW: UnsavedViewDefinition = {
+  config: {},
+  filter: { conditions: [] },
+  colors: { conditions: [] },
+};

--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from "@jest/globals";
+
+describe("sortFields", () => {
+  it("sort single field", () => {
+    expect(true).toStrictEqual(true);
+  });
+});

--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -1,7 +1,205 @@
 import { describe, expect, it } from "@jest/globals";
+import { migrate } from "./settings";
+import type * as v1 from "./v1/settings";
+import type * as v2 from "./v2/settings";
+import type * as base from "./base/settings";
 
-describe("sortFields", () => {
-  it("sort single field", () => {
-    expect(true).toStrictEqual(true);
+describe("migrate from v1 to v2", () => {
+  it("migrates default settings", () => {
+    expect(migrate(v1demo)).toStrictEqual(v2demo);
   });
 });
+
+const v1demo: v1.ProjectsPluginSettings<
+  v1.ProjectDefinition<base.ViewDefinition>
+> = {
+  version: 1,
+  projects: [
+    {
+      path: "Projects - Demo Project",
+      recursive: false,
+      fieldConfig: {},
+      defaultName: "",
+      templates: [],
+      dataview: false,
+      query: "",
+      excludedNotes: [],
+      isDefault: false,
+      name: "Demo project",
+      id: "861e5eaf-162e-4c4b-be1e-7556e2a8c889",
+      views: [
+        {
+          config: {
+            fieldConfig: {
+              name: {
+                width: 360,
+              },
+              path: {
+                hide: true,
+              },
+            },
+          },
+          filter: {
+            conditions: [],
+          },
+          colors: {
+            conditions: [],
+          },
+          name: "Table",
+          id: "0a53aff7-804d-466d-977d-444b9ca6d13a",
+          type: "table",
+        },
+        {
+          config: {
+            groupByField: "status",
+            priorityField: "weight",
+          },
+          filter: {
+            conditions: [],
+          },
+          colors: {
+            conditions: [],
+          },
+          name: "Board",
+          id: "d62f729f-3148-4a5b-93e2-781ff5be7542",
+          type: "board",
+        },
+        {
+          config: {
+            interval: "month",
+            dateField: "due",
+            checkField: "published",
+          },
+          filter: {
+            conditions: [],
+          },
+          colors: {
+            conditions: [],
+          },
+          name: "Calendar",
+          id: "1f1b74a7-ab7b-4fb5-8a18-0cb18f997aa7",
+          type: "calendar",
+        },
+        {
+          config: {
+            coverField: "image",
+          },
+          filter: {
+            conditions: [],
+          },
+          colors: {
+            conditions: [],
+          },
+          name: "Gallery",
+          id: "64713d5a-683d-4f19-9cf9-d90dde311fc8",
+          type: "gallery",
+        },
+      ],
+    },
+  ],
+  preferences: {
+    frontmatter: {
+      quoteStrings: "PLAIN",
+    },
+    projectSizeLimit: 1000,
+  },
+};
+
+const v2demo: v2.ProjectsPluginSettings<
+  v2.ProjectDefinition<base.ViewDefinition>
+> = {
+  version: 2,
+  projects: [
+    {
+      fieldConfig: {},
+      defaultName: "",
+      templates: [],
+      excludedNotes: [],
+      isDefault: false,
+      dataSource: {
+        kind: "folder",
+        config: {
+          path: "Projects - Demo Project",
+          recursive: false,
+        },
+      },
+      newNotesFolder: "",
+      views: [
+        {
+          config: {
+            fieldConfig: {
+              name: {
+                width: 360,
+              },
+              path: {
+                hide: true,
+              },
+            },
+          },
+          filter: {
+            conditions: [],
+          },
+          colors: {
+            conditions: [],
+          },
+          name: "Table",
+          id: "0a53aff7-804d-466d-977d-444b9ca6d13a",
+          type: "table",
+        },
+        {
+          config: {
+            groupByField: "status",
+            priorityField: "weight",
+          },
+          filter: {
+            conditions: [],
+          },
+          colors: {
+            conditions: [],
+          },
+          name: "Board",
+          id: "d62f729f-3148-4a5b-93e2-781ff5be7542",
+          type: "board",
+        },
+        {
+          config: {
+            interval: "month",
+            dateField: "due",
+            checkField: "published",
+          },
+          filter: {
+            conditions: [],
+          },
+          colors: {
+            conditions: [],
+          },
+          name: "Calendar",
+          id: "1f1b74a7-ab7b-4fb5-8a18-0cb18f997aa7",
+          type: "calendar",
+        },
+        {
+          config: {
+            coverField: "image",
+          },
+          filter: {
+            conditions: [],
+          },
+          colors: {
+            conditions: [],
+          },
+          name: "Gallery",
+          id: "64713d5a-683d-4f19-9cf9-d90dde311fc8",
+          type: "gallery",
+        },
+      ],
+      name: "Demo project",
+      id: "861e5eaf-162e-4c4b-be1e-7556e2a8c889",
+    },
+  ],
+  preferences: {
+    projectSizeLimit: 1000,
+    frontmatter: {
+      quoteStrings: "PLAIN",
+    },
+  },
+};

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1,191 +1,20 @@
 import { either } from "fp-ts";
 
-export type ViewType = string;
+import type * as base from "./base/settings";
+import * as v1 from "./v1/settings";
+import * as v2 from "./v2/settings";
 
-export interface ViewDefinition {
-  readonly name: string;
-  readonly id: string;
-  readonly type: ViewType;
-  readonly config: Record<string, any>;
-  readonly filter: FilterDefinition;
-  readonly colors: ColorFilterDefinition;
-}
+export * from "./base/settings";
 
-export type UnsavedViewDefinition = Omit<
-  ViewDefinition,
-  "name" | "id" | "type"
->;
+export type ViewDefinition = base.ViewDefinition;
+export type ProjectDefinition = v2.ProjectDefinition<ViewDefinition>;
+export type ProjectsPluginSettings =
+  v2.ProjectsPluginSettings<ProjectDefinition>;
 
-export const DEFAULT_VIEW: UnsavedViewDefinition = {
-  config: {},
-  filter: { conditions: [] },
-  colors: { conditions: [] },
-};
+export const DEFAULT_SETTINGS = v2.DEFAULT_SETTINGS;
+export const DEFAULT_PROJECT = v2.DEFAULT_PROJECT;
+export const DEFAULT_VIEW = v1.DEFAULT_VIEW;
 
-export interface FilterDefinition {
-  readonly conditions: FilterCondition[];
-}
-
-export interface ColorFilterDefinition {
-  readonly conditions: ColorRule[];
-}
-
-export interface ColorRule {
-  color: string;
-  condition: FilterCondition;
-}
-
-export type BaseFilterOperator = "is-empty" | "is-not-empty";
-
-export type StringFilterOperator =
-  | "is"
-  | "is-not"
-  | "contains"
-  | "not-contains";
-
-export function isStringFilterOperator(
-  op: FilterOperator
-): op is StringFilterOperator {
-  return ["is", "is-not", "contains", "not-contains"].includes(op);
-}
-
-export type NumberFilterOperator = "eq" | "neq" | "lt" | "gt" | "lte" | "gte";
-
-export function isNumberFilterOperator(
-  op: FilterOperator
-): op is NumberFilterOperator {
-  return ["eq", "neq", "lt", "gt", "lte", "gte"].includes(op);
-}
-
-export type BooleanFilterOperator = "is-checked" | "is-not-checked";
-
-export function isBooleanFilterOperator(
-  op: FilterOperator
-): op is BooleanFilterOperator {
-  return ["is-checked", "is-not-checked"].includes(op);
-}
-
-export type FilterOperator =
-  | BaseFilterOperator
-  | StringFilterOperator
-  | NumberFilterOperator
-  | BooleanFilterOperator;
-
-export type FilterOperatorType = "unary" | "binary";
-
-export const filterOperatorTypes: Record<FilterOperator, FilterOperatorType> = {
-  "is-empty": "unary",
-  "is-not-empty": "unary",
-  is: "binary",
-  "is-not": "binary",
-  contains: "binary",
-  "not-contains": "binary",
-  eq: "binary",
-  neq: "binary",
-  lt: "binary",
-  gt: "binary",
-  lte: "binary",
-  gte: "binary",
-  "is-checked": "unary",
-  "is-not-checked": "unary",
-};
-
-export interface FilterCondition {
-  readonly field: string;
-  readonly operator: FilterOperator;
-  readonly value?: string;
-}
-
-export type StringFieldConfig = {
-  options?: string[];
-  richText?: boolean;
-};
-
-export type FieldConfig = StringFieldConfig;
-
-export type FolderDataSource = {
-  readonly kind: "folder";
-  readonly config: {
-    readonly path: string;
-    readonly recursive: boolean;
-  };
-};
-
-export type TagDataSource = {
-  readonly kind: "tag";
-  readonly config: {
-    readonly tag: string;
-  };
-};
-
-export type DataviewDataSource = {
-  readonly kind: "dataview";
-  readonly config: {
-    readonly query: string;
-  };
-};
-
-export type ProjectDefinition = {
-  readonly name: string;
-  readonly id: string;
-
-  readonly fieldConfig: { [field: string]: FieldConfig };
-  readonly views: ViewDefinition[];
-  readonly defaultName: string;
-  readonly templates: string[];
-  readonly excludedNotes: string[];
-  readonly isDefault: boolean;
-  readonly dataSource: FolderDataSource | TagDataSource | DataviewDataSource;
-  readonly newNotesFolder: string;
-};
-
-export type UnsavedProjectDefinition = Omit<
-  ProjectDefinition,
-  "name" | "id" | "views"
->;
-
-export const DEFAULT_PROJECT: UnsavedProjectDefinition = {
-  fieldConfig: {},
-  defaultName: "",
-  templates: [],
-  excludedNotes: [],
-  isDefault: false,
-  dataSource: {
-    kind: "folder",
-    config: {
-      path: "",
-      recursive: false,
-    },
-  },
-  newNotesFolder: "",
-};
-export type ProjectsPluginPreferences = {
-  readonly projectSizeLimit: number;
-  readonly frontmatter: {
-    readonly quoteStrings: "PLAIN" | "QUOTE_DOUBLE";
-  };
-};
-
-export type ProjectsPluginSettingsV1 = {
-  readonly version: 1;
-  readonly lastProjectId?: string | undefined;
-  readonly lastViewId?: string | undefined;
-  readonly projects: ProjectDefinition[];
-  readonly preferences: ProjectsPluginPreferences;
-};
-
-export type ProjectsPluginSettings = ProjectsPluginSettingsV1;
-
-export const DEFAULT_SETTINGS: ProjectsPluginSettings = {
-  version: 1,
-  projects: [],
-  preferences: {
-    projectSizeLimit: 1000,
-    frontmatter: {
-      quoteStrings: "PLAIN",
-    },
-  },
-};
 /**
  * migrateSettings accepts the value from Plugin.loadData() and returns the most
  * recent settings. If needed, it applies any necessary migrations.
@@ -194,70 +23,83 @@ export function migrateSettings(
   settings: any
 ): either.Either<Error, ProjectsPluginSettings> {
   if (!settings) {
-    return either.right(Object.assign({}, DEFAULT_SETTINGS));
+    return either.right(Object.assign({}, v2.DEFAULT_SETTINGS));
   }
 
   if ("version" in settings && typeof settings.version === "number") {
-    // Apply defaults to any saved projects.
-    if ("projects" in settings && Array.isArray(settings.projects)) {
-      return either.tryCatch(() => {
-        return {
-          ...DEFAULT_SETTINGS,
-          ...settings,
-          projects: settings.projects.map(loadProject),
-          preferences: Object.assign({}, DEFAULT_SETTINGS.preferences),
-        };
-      }, either.toError);
+    if (settings.version === 1) {
+      return either.right(migrate(v1.resolve(settings)));
+    } else if (settings.version === 2) {
+      return either.right(v2.resolve(settings));
+    } else {
+      return either.left(new Error("Unknown settings version"));
     }
-
-    return either.right({
-      ...DEFAULT_SETTINGS,
-      ...settings,
-    });
   }
 
-  return either.left(new Error("Missing version"));
+  return either.left(new Error("Missing settings version"));
 }
 
-// loadProject returns a complete project definition, or throws an exception.
-function loadProject(project: Partial<ProjectDefinition>): ProjectDefinition {
-  const res: UnsavedProjectDefinition = {
-    ...DEFAULT_PROJECT,
-    ...project,
+export function migrate(
+  v1settings: v1.ProjectsPluginSettings<
+    v1.ProjectDefinition<base.ViewDefinition>
+  >
+): v2.ProjectsPluginSettings<v2.ProjectDefinition<base.ViewDefinition>> {
+  return {
+    version: 2,
+    projects: v1settings.projects.map(migrateProject),
+    preferences: v1settings.preferences,
+  };
+}
+
+function migrateProject(
+  v1project: v1.ProjectDefinition<base.ViewDefinition>
+): v2.ProjectDefinition<base.ViewDefinition> {
+  const {
+    name,
+    id,
+    fieldConfig,
+    templates,
+    defaultName,
+    excludedNotes,
+    isDefault,
+    views,
+  } = v1project;
+
+  const common = {
+    name,
+    id,
+    fieldConfig,
+    defaultName,
+    templates,
+    excludedNotes,
+    isDefault,
+    views,
   };
 
-  if ("name" in res && "id" in res) {
-    const { name, id } = res;
-
-    if (isString(name) && isString(id)) {
-      if ("views" in res && Array.isArray(res.views)) {
-        return { ...res, name, id, views: res.views.map(loadView) };
-      }
-      return { ...res, name, id, views: [] };
-    }
-  }
-
-  throw new Error("Invalid project definition");
-}
-
-// loadProject returns a complete view definition, or throws an exception.
-function loadView(view: Partial<ViewDefinition>): ViewDefinition {
-  const res: UnsavedViewDefinition = {
-    ...DEFAULT_VIEW,
-    ...view,
+  return {
+    ...common,
+    newNotesFolder: "",
+    dataSource: migrateDataSource(v1project),
   };
-
-  if ("name" in res && "id" in res && "type" in res) {
-    const { name, id, type } = res;
-
-    if (isString(name) && isString(id) && isString(type)) {
-      return { ...res, name, id, type };
-    }
-  }
-
-  throw new Error("Invalid view definition");
 }
 
-const isString = (value: unknown): value is string => {
-  return typeof value === "string";
-};
+function migrateDataSource(
+  project: v1.ProjectDefinition<base.ViewDefinition>
+): v2.DataSource {
+  if (project.dataview) {
+    return {
+      kind: "dataview",
+      config: {
+        query: project.query,
+      },
+    };
+  }
+
+  return {
+    kind: "folder",
+    config: {
+      path: project.path,
+      recursive: project.recursive,
+    },
+  };
+}

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1,6 +1,6 @@
 import { either } from "fp-ts";
 
-import type * as base from "./base/settings";
+import * as base from "./base/settings";
 import * as v1 from "./v1/settings";
 import * as v2 from "./v2/settings";
 
@@ -13,7 +13,7 @@ export type ProjectsPluginSettings =
 
 export const DEFAULT_SETTINGS = v2.DEFAULT_SETTINGS;
 export const DEFAULT_PROJECT = v2.DEFAULT_PROJECT;
-export const DEFAULT_VIEW = v1.DEFAULT_VIEW;
+export const DEFAULT_VIEW = base.DEFAULT_VIEW;
 
 /**
  * migrateSettings accepts the value from Plugin.loadData() and returns the most

--- a/src/settings/v1/settings.test.ts
+++ b/src/settings/v1/settings.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "@jest/globals";
+import { resolve } from "./settings";
+
+describe("resolve v2", () => {
+  it("resolves minimum", () => {
+    const got = resolve({ version: 1 });
+
+    expect(got).toStrictEqual({
+      version: 1,
+      projects: [],
+      preferences: {
+        frontmatter: {
+          quoteStrings: "PLAIN",
+        },
+        projectSizeLimit: 1000,
+      },
+    });
+  });
+
+  it("resolves an empty project with defaults", () => {
+    const got = resolve({ version: 1, projects: [{ name: "Foo", id: "foo" }] });
+
+    expect(got).toStrictEqual({
+      version: 1,
+      projects: [
+        {
+          name: "Foo",
+          id: "foo",
+          fieldConfig: {},
+          defaultName: "",
+          templates: [],
+          excludedNotes: [],
+          isDefault: false,
+          views: [],
+          dataview: false,
+          path: "",
+          query: "",
+          recursive: false,
+        },
+      ],
+      preferences: {
+        frontmatter: {
+          quoteStrings: "PLAIN",
+        },
+        projectSizeLimit: 1000,
+      },
+    });
+  });
+});

--- a/src/settings/v1/settings.ts
+++ b/src/settings/v1/settings.ts
@@ -1,19 +1,9 @@
-import type {
-  FieldConfig,
-  ProjectsPluginPreferences,
-  ViewDefinition,
+import {
+  DEFAULT_VIEW,
+  type FieldConfig,
+  type ProjectsPluginPreferences,
+  type ViewDefinition,
 } from "../base/settings";
-
-export type UnsavedViewDefinition = Omit<
-  ViewDefinition,
-  "name" | "id" | "type"
->;
-
-export const DEFAULT_VIEW: UnsavedViewDefinition = {
-  config: {},
-  filter: { conditions: [] },
-  colors: { conditions: [] },
-};
 
 export type ProjectDefinition<ViewDefinition> = {
   readonly name: string;

--- a/src/settings/v1/settings.ts
+++ b/src/settings/v1/settings.ts
@@ -1,0 +1,119 @@
+import type {
+  FieldConfig,
+  ProjectsPluginPreferences,
+  ViewDefinition,
+} from "../base/settings";
+
+export type UnsavedViewDefinition = Omit<
+  ViewDefinition,
+  "name" | "id" | "type"
+>;
+
+export const DEFAULT_VIEW: UnsavedViewDefinition = {
+  config: {},
+  filter: { conditions: [] },
+  colors: { conditions: [] },
+};
+
+export type ProjectDefinition<ViewDefinition> = {
+  readonly name: string;
+  readonly id: string;
+  readonly path: string;
+  readonly recursive: boolean;
+  readonly fieldConfig: { [field: string]: FieldConfig };
+  readonly views: ViewDefinition[];
+  readonly defaultName: string;
+  readonly templates: string[];
+  readonly dataview: boolean;
+  readonly query: string;
+  readonly excludedNotes: string[];
+  readonly isDefault: boolean;
+};
+
+export type ProjectsPluginSettings<ProjectDefinition> = {
+  readonly version: 1;
+  readonly lastProjectId?: string | undefined;
+  readonly lastViewId?: string | undefined;
+  readonly projects: ProjectDefinition[];
+  readonly preferences: ProjectsPluginPreferences;
+};
+
+export const DEFAULT_SETTINGS: ProjectsPluginSettings<
+  ProjectDefinition<ViewDefinition>
+> = {
+  version: 1,
+  projects: [],
+  preferences: {
+    projectSizeLimit: 1000,
+    frontmatter: {
+      quoteStrings: "PLAIN",
+    },
+  },
+};
+
+export type UnsavedProjectDefinition = Omit<
+  ProjectDefinition<ViewDefinition>,
+  "name" | "id" | "views"
+>;
+
+export const DEFAULT_PROJECT: UnsavedProjectDefinition = {
+  path: "",
+  recursive: false,
+  fieldConfig: {},
+  defaultName: "",
+  templates: [],
+  dataview: false,
+  query: "",
+  excludedNotes: [],
+  isDefault: false,
+};
+
+export type UnresolvedSettings = {
+  readonly version: 1;
+} & Partial<
+  ProjectsPluginSettings<Partial<ProjectDefinition<Partial<ViewDefinition>>>>
+>;
+
+export function resolve(
+  unresolved: UnresolvedSettings
+): ProjectsPluginSettings<ProjectDefinition<ViewDefinition>> {
+  return {
+    ...DEFAULT_SETTINGS,
+    ...unresolved,
+    projects: unresolved.projects?.map(resolveProject) ?? [],
+  };
+}
+
+function resolveProject(
+  unresolved: Partial<ProjectDefinition<Partial<ViewDefinition>>>
+): ProjectDefinition<ViewDefinition> {
+  const { name, id } = unresolved;
+
+  if (name && id) {
+    return {
+      ...DEFAULT_PROJECT,
+      ...unresolved,
+      name,
+      id,
+      views: unresolved.views?.map(resolveView) ?? [],
+    };
+  }
+
+  throw new Error("Invalid project definition");
+}
+
+function resolveView(unresolved: Partial<ViewDefinition>): ViewDefinition {
+  const { name, id, type } = unresolved;
+
+  if (name && id && type) {
+    return {
+      ...DEFAULT_VIEW,
+      ...unresolved,
+      name,
+      id,
+      type,
+    };
+  }
+
+  throw new Error("Invalid view definition");
+}

--- a/src/settings/v2/settings.test.ts
+++ b/src/settings/v2/settings.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "@jest/globals";
+import { resolve } from "./settings";
+
+describe("resolve v2", () => {
+  it("resolves minimum", () => {
+    const got = resolve({ version: 2 });
+
+    expect(got).toStrictEqual({
+      version: 2,
+      projects: [],
+      preferences: {
+        frontmatter: {
+          quoteStrings: "PLAIN",
+        },
+        projectSizeLimit: 1000,
+      },
+    });
+  });
+
+  it("resolves an empty project with defaults", () => {
+    const got = resolve({ version: 2, projects: [{ name: "Foo", id: "foo" }] });
+
+    expect(got).toStrictEqual({
+      version: 2,
+      projects: [
+        {
+          name: "Foo",
+          id: "foo",
+          fieldConfig: {},
+          defaultName: "",
+          templates: [],
+          excludedNotes: [],
+          isDefault: false,
+          dataSource: {
+            kind: "folder",
+            config: {
+              path: "",
+              recursive: false,
+            },
+          },
+          newNotesFolder: "",
+          views: [],
+        },
+      ],
+      preferences: {
+        frontmatter: {
+          quoteStrings: "PLAIN",
+        },
+        projectSizeLimit: 1000,
+      },
+    });
+  });
+});

--- a/src/settings/v2/settings.ts
+++ b/src/settings/v2/settings.ts
@@ -1,0 +1,135 @@
+import type {
+  FieldConfig,
+  ProjectsPluginPreferences,
+  ViewDefinition,
+} from "../base/settings";
+import { DEFAULT_VIEW } from "../v1/settings";
+
+export type ProjectDefinition<ViewDefinition> = {
+  readonly name: string;
+  readonly id: string;
+
+  readonly fieldConfig: { [field: string]: FieldConfig };
+  readonly views: ViewDefinition[];
+  readonly defaultName: string;
+  readonly templates: string[];
+  readonly excludedNotes: string[];
+  readonly isDefault: boolean;
+  readonly dataSource: DataSource;
+  readonly newNotesFolder: string;
+};
+
+export type DataSource = FolderDataSource | TagDataSource | DataviewDataSource;
+
+export type FolderDataSource = {
+  readonly kind: "folder";
+  readonly config: {
+    readonly path: string;
+    readonly recursive: boolean;
+  };
+};
+
+export type TagDataSource = {
+  readonly kind: "tag";
+  readonly config: {
+    readonly tag: string;
+  };
+};
+
+export type DataviewDataSource = {
+  readonly kind: "dataview";
+  readonly config: {
+    readonly query: string;
+  };
+};
+
+export type UnsavedProjectDefinition = Omit<
+  ProjectDefinition<ViewDefinition>,
+  "name" | "id"
+>;
+
+export type ProjectsPluginSettings<T> = {
+  readonly version: 2;
+  readonly projects: T[];
+  readonly preferences: ProjectsPluginPreferences;
+};
+
+export const DEFAULT_PROJECT: UnsavedProjectDefinition = {
+  fieldConfig: {},
+  defaultName: "",
+  templates: [],
+  excludedNotes: [],
+  isDefault: false,
+  dataSource: {
+    kind: "folder",
+    config: {
+      path: "",
+      recursive: false,
+    },
+  },
+  newNotesFolder: "",
+  views: [],
+};
+
+export const DEFAULT_SETTINGS: ProjectsPluginSettings<
+  ProjectDefinition<ViewDefinition>
+> = {
+  version: 2,
+  projects: [],
+  preferences: {
+    projectSizeLimit: 1000,
+    frontmatter: {
+      quoteStrings: "PLAIN",
+    },
+  },
+};
+
+export type UnresolvedSettings = {
+  readonly version: 2;
+} & Partial<
+  ProjectsPluginSettings<Partial<ProjectDefinition<Partial<ViewDefinition>>>>
+>;
+
+export function resolve(
+  unresolved: UnresolvedSettings
+): ProjectsPluginSettings<ProjectDefinition<ViewDefinition>> {
+  return {
+    ...DEFAULT_SETTINGS,
+    ...unresolved,
+    projects: unresolved.projects?.map(resolveProject) ?? [],
+  };
+}
+
+function resolveProject(
+  unresolved: Partial<ProjectDefinition<Partial<ViewDefinition>>>
+): ProjectDefinition<ViewDefinition> {
+  const { name, id } = unresolved;
+
+  if (name && id) {
+    return {
+      ...DEFAULT_PROJECT,
+      ...unresolved,
+      name,
+      id,
+      views: unresolved.views?.map(resolveView) ?? [],
+    };
+  }
+
+  throw new Error("Invalid project definition");
+}
+
+function resolveView(unresolved: Partial<ViewDefinition>): ViewDefinition {
+  const { name, id, type } = unresolved;
+
+  if (name && id && type) {
+    return {
+      ...DEFAULT_VIEW,
+      ...unresolved,
+      name,
+      id,
+      type,
+    };
+  }
+
+  throw new Error("Invalid view definition");
+}

--- a/src/settings/v2/settings.ts
+++ b/src/settings/v2/settings.ts
@@ -3,7 +3,7 @@ import type {
   ProjectsPluginPreferences,
   ViewDefinition,
 } from "../base/settings";
-import { DEFAULT_VIEW } from "../v1/settings";
+import { DEFAULT_VIEW } from "../base/settings";
 
 export type ProjectDefinition<ViewDefinition> = {
   readonly name: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,19 +101,40 @@ export type StringFieldConfig = {
 
 export type FieldConfig = StringFieldConfig;
 
+export type FolderDataSource = {
+  readonly kind: "folder";
+  readonly config: {
+    readonly path: string;
+    readonly recursive: boolean;
+  };
+};
+
+export type TagDataSource = {
+  readonly kind: "tag";
+  readonly config: {
+    readonly tag: string;
+  };
+};
+
+export type DataviewDataSource = {
+  readonly kind: "dataview";
+  readonly config: {
+    readonly query: string;
+  };
+};
+
 export type ProjectDefinition = {
   readonly name: string;
   readonly id: string;
-  readonly path: string;
-  readonly recursive: boolean;
+
   readonly fieldConfig: { [field: string]: FieldConfig };
   readonly views: ViewDefinition[];
   readonly defaultName: string;
   readonly templates: string[];
-  readonly dataview: boolean;
-  readonly query: string;
   readonly excludedNotes: string[];
   readonly isDefault: boolean;
+  readonly dataSource: FolderDataSource | TagDataSource | DataviewDataSource;
+  readonly newNotesFolder: string;
 };
 
 export type UnsavedProjectDefinition = Omit<
@@ -122,13 +143,17 @@ export type UnsavedProjectDefinition = Omit<
 >;
 
 export const DEFAULT_PROJECT: UnsavedProjectDefinition = {
-  path: "",
-  recursive: false,
   fieldConfig: {},
   defaultName: "",
   templates: [],
-  dataview: false,
-  query: "",
   excludedNotes: [],
   isDefault: false,
+  dataSource: {
+    kind: "folder",
+    config: {
+      path: "",
+      recursive: false,
+    },
+  },
+  newNotesFolder: "",
 };

--- a/src/views/Board/BoardView.svelte
+++ b/src/views/Board/BoardView.svelte
@@ -15,7 +15,7 @@
   import type { ViewApi } from "src/lib/view-api";
   import { CreateNoteModal } from "src/modals/create-note-modal";
   import { EditNoteModal } from "src/modals/edit-note-modal";
-  import type { ProjectDefinition } from "src/types";
+  import type { ProjectDefinition } from "src/settings/settings";
   import {
     fieldToSelectableValue,
     setRecordColorContext,

--- a/src/views/Calendar/CalendarView.svelte
+++ b/src/views/Calendar/CalendarView.svelte
@@ -15,7 +15,7 @@
   import type { ViewApi } from "src/lib/view-api";
   import { CreateNoteModal } from "src/modals/create-note-modal";
   import { EditNoteModal } from "src/modals/edit-note-modal";
-  import type { ProjectDefinition } from "src/types";
+  import type { ProjectDefinition } from "src/settings/settings";
   import {
     fieldToSelectableValue,
     setRecordColorContext,

--- a/src/views/Table/TableView.svelte
+++ b/src/views/Table/TableView.svelte
@@ -6,7 +6,6 @@
   import type { ViewApi } from "src/lib/view-api";
   import { CreateNoteModal } from "src/modals/create-note-modal";
   import { EditNoteModal } from "src/modals/edit-note-modal";
-  import type { ProjectDefinition } from "src/types";
 
   import type {
     GridColDef,
@@ -25,6 +24,7 @@
   import { ConfigureFieldModal } from "src/modals/configure-field";
   import { settings } from "src/lib/stores/settings";
   import { sortFields } from "./helpers";
+  import type { ProjectDefinition } from "src/settings/settings";
 
   export let project: ProjectDefinition;
   export let frame: DataFrame;


### PR DESCRIPTION
## Tag-based projects

This PR adds a new data source that filters notes based on whether they contain a certain tag or not.

## New notes location

Neither Dataview or Tag projects have no inherent folder associated with them. Because of this, this PR also introduces a new project setting called "Location for new notes".

For folder-based projects, the location defaults to the same folder as the project, but it can be overridden.

## Custom View API

`ProjectDefinition` now has a `dataSource` property which describes the dataSource used and its settings. You can use the `kind` property to determine which data source has been configured.

**Folder-based projects**

```ts
dataSource: {
  kind: "folder",
  config: {
    path: "Work",
    recursive: false,
  },
}
```

**Tag-based projects**

```ts
dataSource: {
  kind: "tag",
  config: {
    tag: "#work",
  },
}
```

**Dataview projects**

```ts
dataSource: {
  kind: "dataview",
  config: {
    query: "SELECT * FROM "Work",
  },
}
```