### PR TITLE
Board and Gallery: Include fields in cards

### DIFF
--- a/src/components/CardMetadata/CardMetadata.svelte
+++ b/src/components/CardMetadata/CardMetadata.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import { Icon } from "obsidian-svelte";
+  import { DataFieldType, type DataField, type DataRecord } from "src/lib/data";
+  import Checkbox from "./Checkbox.svelte";
+  import Tags from "./Tags.svelte";
+  import Text from "./Text.svelte";
+  import Date from "./Date.svelte";
+  import Number from "./Number.svelte";
+
+  export let fields: DataField[];
+  export let record: DataRecord;
+</script>
+
+{#each fields as field}
+  {@const value = record.values[field.name]}
+  {#if value !== undefined && value !== null}
+    <div class="field-label">
+      <div class="setting-item-description" style:margin-bottom={"4px"}>
+        {field.name}
+      </div>
+      {#if field.repeated}
+        {#if field.type === DataFieldType.String}
+          <Tags {field} {value} />
+        {/if}
+      {:else if field.type === DataFieldType.Boolean}
+        <Checkbox {field} {value} />
+      {:else if field.type === DataFieldType.String}
+        <Text {field} {value} />
+      {:else if field.type === DataFieldType.Number}
+        <Number {field} {value} />
+      {:else if field.type === DataFieldType.Date}
+        <Date {value} {field} />
+      {:else}
+        <Icon name="slash" />
+      {/if}
+    </div>
+  {/if}
+{/each}
+
+<style>
+  .field-label {
+    margin-bottom: 8px;
+    overflow: hidden;
+  }
+
+  .field-label:last-child {
+    margin-bottom: 0;
+  }
+</style>

--- a/src/components/CardMetadata/Checkbox.svelte
+++ b/src/components/CardMetadata/Checkbox.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { Switch } from "obsidian-svelte";
+  import {
+    DataFieldType,
+    type DataField,
+    type DataValue,
+    type Optional,
+  } from "src/lib/data";
+
+  export let value: Optional<DataValue>;
+  export let field: DataField;
+</script>
+
+{#if field.type === DataFieldType.Boolean && !field.repeated && typeof value === "boolean"}
+  <Switch checked={value} disabled />
+{/if}

--- a/src/components/CardMetadata/Date.svelte
+++ b/src/components/CardMetadata/Date.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import {
+    DataFieldType,
+    type DataField,
+    type DataValue,
+    type Optional,
+  } from "src/lib/data";
+
+  export let value: Optional<DataValue>;
+  export let field: DataField;
+</script>
+
+{#if field.type === DataFieldType.Date && !field.repeated && value instanceof Date}
+  {Intl.DateTimeFormat().format(value)}
+{/if}

--- a/src/components/CardMetadata/Number.svelte
+++ b/src/components/CardMetadata/Number.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import {
+    DataFieldType,
+    type DataField,
+    type DataValue,
+    type Optional,
+  } from "src/lib/data";
+
+  export let value: Optional<DataValue>;
+  export let field: DataField;
+</script>
+
+{#if field.type === DataFieldType.Number && !field.repeated && typeof value === "number"}
+  {Intl.NumberFormat().format(value)}
+{/if}

--- a/src/components/CardMetadata/Tags.svelte
+++ b/src/components/CardMetadata/Tags.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import {
+    DataFieldType,
+    type DataField,
+    type DataValue,
+    type Optional,
+  } from "src/lib/data";
+  import { TagList } from "../TagList";
+
+  export let value: Optional<DataValue>;
+  export let field: DataField;
+</script>
+
+{#if field.type === DataFieldType.String && field.repeated && Array.isArray(value)}
+  <TagList values={value || []} />
+{/if}

--- a/src/components/CardMetadata/Text.svelte
+++ b/src/components/CardMetadata/Text.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import { MarkdownRenderer } from "obsidian";
+  import type { DataField, DataValue, Optional } from "src/lib/data";
+  import { app, view } from "src/lib/stores/obsidian";
+
+  export let value: Optional<DataValue>;
+  export let field: DataField;
+
+  export let sourcePath: string = "";
+
+  function useMarkdown(node: HTMLElement) {
+    if (typeof value === "string") {
+      MarkdownRenderer.renderMarkdown(value, node, sourcePath, $view);
+    }
+  }
+
+  function handleClick(event: MouseEvent) {
+    const targetEl = event.target as HTMLElement;
+    const closestAnchor =
+      targetEl.tagName === "A" ? targetEl : targetEl.closest("a");
+
+    if (!closestAnchor) {
+      return;
+    }
+
+    event.stopPropagation();
+
+    if (closestAnchor.hasClass("internal-link")) {
+      event.preventDefault();
+
+      const href = closestAnchor.getAttr("href");
+      const newLeaf = event.button === 1 || event.ctrlKey || event.metaKey;
+
+      if (href) {
+        $app.workspace.openLinkText(href, sourcePath, newLeaf);
+      }
+    }
+  }
+</script>
+
+{#if field.typeConfig?.richText}
+  <div use:useMarkdown on:click={handleClick} on:keypress />
+{:else if typeof value === "string"}
+  <div>
+    {value}
+  </div>
+{/if}
+
+<style>
+  div {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  div :global(p:first-child) {
+    margin-top: 0;
+  }
+
+  div :global(p:last-child) {
+    margin-bottom: 0;
+  }
+</style>

--- a/src/components/TagList/TagList.svelte
+++ b/src/components/TagList/TagList.svelte
@@ -6,7 +6,7 @@
   import { InputDialogModal } from "src/modals/input-dialog";
 
   export let values: Optional<DataValue>[];
-  export let edit: boolean;
+  export let edit: boolean = false;
 
   export let onChange: (values: Optional<DataValue>[]) => void = () => {};
 

--- a/src/views/Board/BoardView.svelte
+++ b/src/views/Board/BoardView.svelte
@@ -20,6 +20,7 @@
     fieldToSelectableValue,
     setRecordColorContext,
   } from "src/views/helpers";
+  import { SwitchSelect } from "../Table/components/SwitchSelect";
 
   import { groupRecordsByField } from "./board";
   import { Board } from "./components";
@@ -133,6 +134,20 @@
     }).open();
   }
 
+  function handleIncludeFieldChange(field: string, enabled: boolean) {
+    const includedFields = new Set(config?.includeFields);
+
+    if (enabled) {
+      includedFields.add(field);
+    } else {
+      includedFields.delete(field);
+    }
+
+    config = { ...config, includeFields: [...includedFields] };
+
+    onConfigChange(config);
+  }
+
   setRecordColorContext(getRecordColor);
 </script>
 
@@ -173,6 +188,15 @@
             tooltip="Date fields can't be reprioritized using drag and drop."
           />
         {/if}
+        <SwitchSelect
+          label={"Include fields"}
+          items={fields.map((field) => ({
+            label: field.name,
+            value: field.name,
+            enabled: !!config?.includeFields?.includes(field.name),
+          }))}
+          onChange={handleIncludeFieldChange}
+        />
         <IconButton
           icon="settings"
           on:click={() => {
@@ -206,6 +230,9 @@
         onRecordClick={handleRecordClick}
         onRecordAdd={handleRecordAdd}
         columnWidth={config?.columnWidth ?? 270}
+        fields={fields.filter(
+          (field) => !!config?.includeFields?.includes(field.name)
+        )}
       />
     </div>
   </ViewContent>

--- a/src/views/Board/components/Board/Board.svelte
+++ b/src/views/Board/components/Board/Board.svelte
@@ -19,6 +19,7 @@
   export let columnWidth: number;
   export let onSortColumns: (names: string[]) => void;
   export let dragDisabled: boolean;
+  export let fields: DataField[];
 
   const flipDurationMs = 200;
 
@@ -55,6 +56,7 @@
       onRecordAdd={() => onRecordAdd(column.id)}
       {dragDisabled}
       onRecordUpdate={(record) => onRecordUpdate(column.id, record)}
+      {fields}
     />
   {/each}
 </div>

--- a/src/views/Board/components/Board/BoardColumn.svelte
+++ b/src/views/Board/components/Board/BoardColumn.svelte
@@ -15,6 +15,7 @@
   export let readonly: boolean;
   export let dragDisabled: boolean = false;
   export let onRecordUpdate: (record: DataRecord) => void;
+  export let fields: DataField[];
 
   $: prioritized = getPrioritizedRecords(records, groupByPriority);
   $: unprioritized = getUnprioritizedRecords(records, groupByPriority);
@@ -66,6 +67,7 @@
         {onRecordClick}
         onDrop={handleDropPrioritized}
         {dragDisabled}
+        {fields}
       />
     </div>
     <div class="column-section unprio">
@@ -75,11 +77,12 @@
         {onRecordClick}
         onDrop={handleDropUnprioritized}
         {dragDisabled}
+        {fields}
       />
     </div>
   {:else}
     <div class="column-section">
-      <CardGroup items={records} {onRecordClick} dragDisabled={true} />
+      <CardGroup items={records} {onRecordClick} dragDisabled={true} {fields} />
     </div>
   {/if}
   {#if !readonly}

--- a/src/views/Board/components/Board/CardGroup.svelte
+++ b/src/views/Board/components/Board/CardGroup.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
   import { InternalLink } from "obsidian-svelte";
-  import type { DataRecord } from "src/lib/data";
+  import type { DataField, DataRecord } from "src/lib/data";
   import { dndzone } from "svelte-dnd-action";
   import { getDisplayName } from "./board-helpers";
   import { app } from "src/lib/stores/obsidian";
   import { flip } from "svelte/animate";
   import { getRecordColorContext } from "src/views/helpers";
+  import CardMetadata from "src/components/CardMetadata/CardMetadata.svelte";
 
   export let items: DataRecord[];
   export let onRecordClick: (record: DataRecord) => void;
   export let onDrop: (records: DataRecord[]) => void = () => {};
   export let dragDisabled: boolean = false;
+  export let fields: DataField[];
 
   const flipDurationMs = 200;
 
@@ -52,25 +54,28 @@
       on:click={() => onRecordClick(item)}
       animate:flip={{ duration: flipDurationMs }}
     >
-      {#if color}
-        <span
-          style="margin-right: 8px; background-color: {color}; width: 5px; border-radius: 9999px;"
-        />
-      {/if}
-      <InternalLink
-        linkText={item.id}
-        sourcePath=""
-        resolved
-        on:open={({ detail: { linkText, sourcePath, newLeaf } }) => {
-          if (newLeaf) {
-            $app.workspace.openLinkText(linkText, sourcePath, newLeaf);
-          } else {
-            onRecordClick(item);
-          }
-        }}
-      >
-        {getDisplayName(item.id)}
-      </InternalLink>
+      <div class="card-header">
+        {#if color}
+          <span
+            style="margin-right: 8px; background-color: {color}; width: 5px; border-radius: 9999px;"
+          />
+        {/if}
+        <InternalLink
+          linkText={item.id}
+          sourcePath=""
+          resolved
+          on:open={({ detail: { linkText, sourcePath, newLeaf } }) => {
+            if (newLeaf) {
+              $app.workspace.openLinkText(linkText, sourcePath, newLeaf);
+            } else {
+              onRecordClick(item);
+            }
+          }}
+        >
+          {getDisplayName(item.id)}
+        </InternalLink>
+      </div>
+      <CardMetadata {fields} record={item} />
     </div>
   {/each}
 </div>
@@ -83,12 +88,21 @@
     min-height: 35px;
   }
 
+  .card-header {
+    display: flex;
+    font-size: 16px;
+    margin-bottom: 8px;
+  }
+
+  .card-header:last-child {
+    margin-bottom: 0;
+  }
+
   .crd {
     background-color: var(--background-primary);
     border-radius: var(--radius-s);
     border: 1px solid var(--background-modifier-border);
     padding: var(--size-4-2);
-    display: flex;
   }
 
   .crd:hover {

--- a/src/views/Board/types.ts
+++ b/src/views/Board/types.ts
@@ -7,4 +7,5 @@ export interface BoardConfig {
       readonly weight: number;
     };
   };
+  readonly includeFields?: string[];
 }

--- a/src/views/Gallery/components/Card/CardContent.svelte
+++ b/src/views/Gallery/components/Card/CardContent.svelte
@@ -5,6 +5,5 @@
 <style>
   div {
     padding: 8px;
-    display: flex;
   }
 </style>

--- a/src/views/Gallery/types.ts
+++ b/src/views/Gallery/types.ts
@@ -2,4 +2,5 @@ export interface GalleryConfig {
   readonly coverField?: string;
   readonly fitStyle?: string;
   readonly cardWidth?: number;
+  readonly includeFields?: string[];
 }


### PR DESCRIPTION
This PR introduces a new feature to display fields in cards for the Board and Gallery views.

Including fields in cards allows you to include additional information in your cards for an at-a-glance view.

Fixes #53 