### PR TITLE
Add file system abstraction

### DIFF
--- a/src/app/App.svelte
+++ b/src/app/App.svelte
@@ -77,7 +77,7 @@
             {project}
             {view}
             readonly={source.readonly()}
-            api={new ViewApi($app, source, $api)}
+            api={new ViewApi(source, $api)}
             onConfigChange={settings.updateViewConfig}
             {frame}
           />

--- a/src/app/onboarding/onboarding-modal.ts
+++ b/src/app/onboarding/onboarding-modal.ts
@@ -6,7 +6,7 @@ export class OnboardingModal extends Modal {
   component?: Onboarding;
 
   constructor(
-    app: App,
+    readonly app: App,
     readonly onCreate: () => void,
     readonly onTry: () => void
   ) {

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,114 +1,61 @@
-import { TAbstractFile, TFile, type Plugin } from "obsidian";
 import { get } from "svelte/store";
-import {} from "obsidian-dataview";
-
-import { capabilities } from "src/lib/stores/capabilities";
 import { dataFrame, dataSource } from "src/lib/stores/dataframe";
+import type { IFileSystemWatcher } from "./lib/filesystem/filesystem";
 import { DataviewDataSource } from "./lib/datasources/dataview/dataview";
+import type { DataSource } from "./lib/data";
+
+function withDataSource(cb: (source: DataSource) => Promise<void>) {
+  const source = get(dataSource);
+  if (!source) {
+    return;
+  }
+
+  // This is a hack to trigger the Dataview query to run again when a file changes.
+  if (source instanceof DataviewDataSource) {
+    dataSource.set(source);
+    return;
+  }
+
+  return cb(source);
+}
 
 // registerFileEvents keeps the file index up-to-date while plugin is running.
-export function registerFileEvents(plugin: Plugin) {
-  // Use Dataview as index if enabled.
-  if (get(capabilities).dataview) {
-    plugin.registerEvent(
-      plugin.app.metadataCache.on(
-        // @ts-expect-error
-        "dataview:metadata-change",
-        async (type: string, file: TAbstractFile, oldPath: string) => {
-          if (file instanceof TFile) {
-            const source = get(dataSource);
-            if (!source) {
-              return;
-            }
+export function registerFileEvents(watcher: IFileSystemWatcher) {
+  watcher.onCreate(async (file) => {
+    withDataSource(async (source) => {
+      if (source.includes(file.path)) {
+        dataFrame.merge(await source.queryOne(file, get(dataFrame).fields));
+      }
+    });
+  });
+  watcher.onRename(async (file, oldPath) => {
+    withDataSource(async (source) => {
+      if (source.includes(file.path)) {
+        dataFrame.deleteRecord(oldPath);
+        dataFrame.merge(await source.queryOne(file, get(dataFrame).fields));
+      }
+    });
+  });
 
-            // This is a hack to trigger the Dataview query to run again.
-            if (source instanceof DataviewDataSource) {
-              dataSource.set(source);
-              return;
-            }
+  watcher.onDelete(async (file) => {
+    withDataSource(async (source) => {
+      if (source.includes(file.path)) {
+        dataFrame.deleteRecord(file.path);
+      }
+    });
+  });
 
-            const recordExists = !!get(dataFrame).records.find(
-              (record) => record.id === file.path
-            );
+  watcher.onChange(async (file) => {
+    withDataSource(async (source) => {
+      const recordExists = !!get(dataFrame).records.find(
+        (record) => record.id === file.path
+      );
 
-            if (source.includes(file.path)) {
-              switch (type) {
-                case "update":
-                  dataFrame.merge(
-                    await source.queryOne(file, get(dataFrame).fields)
-                  );
-                  break;
-                case "delete":
-                  dataFrame.deleteRecord(file.path);
-                  break;
-                case "rename":
-                  dataFrame.deleteRecord(oldPath);
-                  dataFrame.merge(
-                    await source.queryOne(file, get(dataFrame).fields)
-                  );
-                  break;
-              }
-            } else if (recordExists) {
-              dataFrame.deleteRecord(file.path);
-            }
-          }
-        }
-      )
-    );
-  } else {
-    plugin.registerEvent(
-      plugin.app.vault.on("create", async (file) => {
-        if (file instanceof TFile) {
-          const source = get(dataSource);
-          if (source?.includes(file.path)) {
-            dataFrame.merge(await source.queryOne(file, get(dataFrame).fields));
-          }
-        }
-      })
-    );
-
-    plugin.registerEvent(
-      plugin.app.vault.on("rename", async (file, oldPath) => {
-        if (file instanceof TFile) {
-          const source = get(dataSource);
-          if (source?.includes(file.path)) {
-            dataFrame.deleteRecord(oldPath);
-            dataFrame.merge(await source.queryOne(file, get(dataFrame).fields));
-          }
-        }
-      })
-    );
-
-    plugin.registerEvent(
-      plugin.app.vault.on("delete", (file) => {
-        if (file instanceof TFile) {
-          const source = get(dataSource);
-          if (source?.includes(file.path)) {
-            dataFrame.deleteRecord(file.path);
-          }
-        }
-      })
-    );
-
-    plugin.registerEvent(
-      plugin.app.metadataCache.on("changed", async (file) => {
-        if (file instanceof TFile) {
-          const source = get(dataSource);
-          if (!source) {
-            return;
-          }
-
-          const recordExists = !!get(dataFrame).records.find(
-            (record) => record.id === file.path
-          );
-
-          if (source.includes(file.path)) {
-            dataFrame.merge(await source.queryOne(file, get(dataFrame).fields));
-          } else if (recordExists) {
-            dataFrame.deleteRecord(file.path);
-          }
-        }
-      })
-    );
-  }
+      if (source.includes(file.path)) {
+        dataFrame.merge(await source.queryOne(file, get(dataFrame).fields));
+      } else if (recordExists) {
+        dataFrame.deleteRecord(file.path);
+      }
+    });
+  });
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,10 +1,10 @@
-import type { TFile } from "obsidian";
 import type {
   FieldConfig,
   ProjectDefinition,
   ProjectsPluginPreferences,
 } from "src/settings/settings";
 import type { RecordError } from "./datasources/frontmatter/frontmatter";
+import type { IFile } from "./filesystem/filesystem";
 
 /**
  * DataFrame is the core data structure that contains structured data for a
@@ -139,7 +139,7 @@ export abstract class DataSource {
    *
    * @param fields contains existing fields, to be able to parse file into the existing schema.
    */
-  abstract queryOne(file: TFile, fields: DataField[]): Promise<DataFrame>;
+  abstract queryOne(file: IFile, fields: DataField[]): Promise<DataFrame>;
 
   /**
    * includes returns whether a path belongs to the current project.

--- a/src/lib/datasources/folder/folder.ts
+++ b/src/lib/datasources/folder/folder.ts
@@ -1,4 +1,4 @@
-import type { App } from "obsidian";
+import type { IFileSystem } from "src/lib/filesystem/filesystem";
 import type {
   ProjectDefinition,
   ProjectsPluginPreferences,
@@ -8,11 +8,11 @@ import { FrontMatterDataSource } from "../frontmatter/frontmatter";
 
 export class FolderDataSource extends FrontMatterDataSource {
   constructor(
-    readonly app: App,
+    readonly fileSystem: IFileSystem,
     project: ProjectDefinition,
     preferences: ProjectsPluginPreferences
   ) {
-    super(app, project, preferences);
+    super(fileSystem, project, preferences);
   }
 
   includes(path: string): boolean {

--- a/src/lib/filesystem/filesystem.ts
+++ b/src/lib/filesystem/filesystem.ts
@@ -1,0 +1,58 @@
+import { either } from "fp-ts";
+import produce from "immer";
+import { encodeFrontMatter, decodeFrontMatter } from "../metadata";
+
+export abstract class IFile {
+  abstract get basename(): string;
+  abstract get path(): string;
+
+  abstract write(content: string): Promise<void>;
+  abstract read(): Promise<string>;
+  abstract delete(): Promise<void>;
+  abstract readTags(): Set<string>;
+
+  async readValue(field: string): Promise<any> {
+    const values = await this.readValues();
+
+    return values[field];
+  }
+
+  async writeValue(field: string, value: any): Promise<void> {
+    this.writeValues(
+      produce(await this.readValues(), (draft) => {
+        draft[field] = value;
+      })
+    );
+  }
+
+  async readValues(): Promise<Record<string, any>> {
+    const data = await this.read();
+
+    const values = decodeFrontMatter(data);
+
+    return either.isRight(values) ? values.right : {};
+  }
+
+  async writeValues(values: Record<string, any>): Promise<void> {
+    const data = await this.read();
+
+    const updatedData = encodeFrontMatter(data, values, "PLAIN");
+
+    if (either.isRight(updatedData)) {
+      this.write(updatedData.right);
+    }
+  }
+}
+
+export interface IFileSystem {
+  create(path: string, content: string): Promise<IFile>;
+  getFile(path: string): IFile | null;
+  getAllFiles(): IFile[];
+}
+
+export interface IFileSystemWatcher {
+  onCreate(callback: (file: IFile) => Promise<void>): void;
+  onDelete(callback: (file: IFile) => Promise<void>): void;
+  onChange(callback: (file: IFile) => Promise<void>): void;
+  onRename(callback: (file: IFile, oldPath: string) => Promise<void>): void;
+}

--- a/src/lib/filesystem/inmem/inmem.ts
+++ b/src/lib/filesystem/inmem/inmem.ts
@@ -1,0 +1,63 @@
+import { IFile, type IFileSystem } from "../filesystem";
+
+class InMemFile extends IFile {
+  constructor(
+    private readonly _path: string,
+    private _content: string,
+    private fileSystem: InMemFileSystem
+  ) {
+    super();
+  }
+
+  get basename(): string {
+    return this._path.split("/").at(-1) ?? this.path;
+  }
+
+  get path(): string {
+    return this._path;
+  }
+
+  async read(): Promise<string> {
+    return this._content;
+  }
+
+  async write(content: string): Promise<void> {
+    this._content = content;
+  }
+
+  async delete(): Promise<void> {
+    this.fileSystem.delete(this._path);
+  }
+
+  readTags(): Set<string> {
+    throw new Error("Method not implemented.");
+  }
+}
+
+export class InMemFileSystem implements IFileSystem {
+  constructor(readonly files: Record<string, InMemFile>) {}
+
+  async create(path: string, content: string): Promise<IFile> {
+    if (this.files[path]) {
+      throw new Error("File already exist");
+    }
+
+    const file = new InMemFile(path, content, this);
+
+    this.files[path] = file;
+
+    return file;
+  }
+
+  async delete(path: string): Promise<void> {
+    delete this.files[path];
+  }
+
+  getAllFiles(): IFile[] {
+    return Object.values(this.files);
+  }
+
+  getFile(path: string): IFile | null {
+    return this.files[path] ?? null;
+  }
+}

--- a/src/lib/filesystem/obsidian/obsidian.ts
+++ b/src/lib/filesystem/obsidian/obsidian.ts
@@ -1,0 +1,179 @@
+import {
+  App,
+  normalizePath,
+  Plugin,
+  TFile,
+  type CachedMetadata,
+} from "obsidian";
+import { notEmpty } from "src/lib/helpers";
+import {
+  IFile,
+  type IFileSystem,
+  type IFileSystemWatcher,
+} from "../filesystem";
+
+class ObsidianFile extends IFile {
+  static of(path: string, app: App): IFile {
+    const file = app.vault.getAbstractFileByPath(normalizePath(path));
+
+    if (file instanceof TFile) {
+      return new ObsidianFile(file, app);
+    }
+
+    throw new Error("Not a file");
+  }
+
+  constructor(readonly file: TFile, readonly app: App) {
+    super();
+  }
+
+  get basename(): string {
+    return this.file.basename;
+  }
+  get path(): string {
+    return this.file.path;
+  }
+
+  read(): Promise<string> {
+    return this.app.vault.read(this.file);
+  }
+
+  write(content: string): Promise<void> {
+    return this.app.vault.modify(this.file, content);
+  }
+
+  delete(): Promise<void> {
+    return this.app.vault.trash(this.file, true);
+  }
+
+  readTags(): Set<string> {
+    const cache = this.app.metadataCache.getFileCache(this.file);
+
+    if (cache) {
+      return parseTags(cache);
+    }
+
+    return new Set<string>();
+  }
+}
+
+export class ObsidianFileSystem implements IFileSystem {
+  constructor(readonly app: App) {}
+
+  async create(path: string, content: string): Promise<IFile> {
+    const file = await this.app.vault.create(normalizePath(path), content);
+
+    return new ObsidianFile(file, this.app);
+  }
+
+  async read(path: string): Promise<string> {
+    const file = this.app.vault.getAbstractFileByPath(normalizePath(path));
+    if (file instanceof TFile) {
+      return this.app.vault.cachedRead(file);
+    }
+    return "";
+  }
+
+  async write(path: string, content: string): Promise<void> {
+    const file = this.app.vault.getAbstractFileByPath(normalizePath(path));
+    if (file instanceof TFile) {
+      return this.app.vault.modify(file, content);
+    }
+  }
+
+  async delete(path: string): Promise<void> {
+    const file = this.app.vault.getAbstractFileByPath(normalizePath(path));
+    if (file instanceof TFile) {
+      return this.app.vault.trash(file, true);
+    }
+  }
+
+  getFile(path: string): IFile {
+    return ObsidianFile.of(path, this.app);
+  }
+
+  getAllFiles(): IFile[] {
+    return this.app.vault
+      .getMarkdownFiles()
+      .map((file) => new ObsidianFile(file, this.app));
+  }
+}
+
+export class ObsidianFileSystemWatcher implements IFileSystemWatcher {
+  constructor(readonly plugin: Plugin) {}
+
+  onCreate(callback: (file: IFile) => Promise<void>): void {
+    this.plugin.registerEvent(
+      this.plugin.app.vault.on("create", (file) => {
+        if (file instanceof TFile) {
+          callback(new ObsidianFile(file, app));
+        }
+      })
+    );
+  }
+
+  onChange(callback: (file: IFile) => Promise<void>): void {
+    this.plugin.registerEvent(
+      this.plugin.app.metadataCache.on("changed", (file) => {
+        if (file instanceof TFile) {
+          callback(new ObsidianFile(file, app));
+        }
+      })
+    );
+  }
+
+  onDelete(callback: (file: IFile) => Promise<void>): void {
+    this.plugin.registerEvent(
+      this.plugin.app.vault.on("delete", (file) => {
+        if (file instanceof TFile) {
+          callback(new ObsidianFile(file, app));
+        }
+      })
+    );
+  }
+
+  onRename(callback: (file: IFile, oldPath: string) => Promise<void>): void {
+    this.plugin.registerEvent(
+      this.plugin.app.vault.on("rename", (file, oldPath) => {
+        if (file instanceof TFile) {
+          callback(new ObsidianFile(file, app), oldPath);
+        }
+      })
+    );
+  }
+}
+
+function parseTags(cache: CachedMetadata) {
+  const allTags = new Set<string>();
+
+  const markdownTags = cache.tags?.map((tag) => tag.tag) ?? [];
+
+  markdownTags.forEach((tag) => allTags.add(tag));
+
+  parseFrontMatterTags(cache.frontmatter?.["tags"]).forEach((tag) =>
+    allTags.add(tag)
+  );
+  parseFrontMatterTags(cache.frontmatter?.["tag"]).forEach((tag) =>
+    allTags.add(tag)
+  );
+
+  return allTags;
+}
+
+function parseFrontMatterTags(property: unknown): string[] {
+  const res: string[] = [];
+
+  if (typeof property === "string") {
+    property
+      .split(",")
+      .map((tag) => "#" + tag.trim())
+      .forEach((tag) => res.push(tag));
+  } else if (Array.isArray(property)) {
+    property
+      .filter(notEmpty)
+      .map((tag) => "#" + tag.toString())
+      .forEach((tag) => res.push(tag));
+  }
+
+  return res;
+}

--- a/src/lib/stores/api.ts
+++ b/src/lib/stores/api.ts
@@ -1,7 +1,9 @@
 import { derived } from "svelte/store";
 
 import { DataApi } from "src/lib/data-api";
+import { fileSystem } from "./fileSystem";
 
-import { app } from "./obsidian";
-
-export const api = derived(app, ($app) => new DataApi($app));
+export const api = derived(
+  fileSystem,
+  ($fileSystem) => new DataApi($fileSystem)
+);

--- a/src/lib/stores/fileSystem.ts
+++ b/src/lib/stores/fileSystem.ts
@@ -1,0 +1,5 @@
+import { derived } from "svelte/store";
+import { ObsidianFileSystem } from "../filesystem/obsidian/obsidian";
+import { app } from "src/lib/stores/obsidian";
+
+export const fileSystem = derived(app, ($app) => new ObsidianFileSystem($app));

--- a/src/lib/view-api.ts
+++ b/src/lib/view-api.ts
@@ -1,20 +1,14 @@
-import type { App } from "obsidian";
 import { get } from "svelte/store";
 
 import type { DataField, DataRecord, DataSource } from "./data";
 import type { DataApi } from "./data-api";
-import { filesFromRecords } from "./obsidian";
 import { dataFrame } from "./stores/dataframe";
 
 /**
  * ViewApi provides an write API for views.
  */
 export class ViewApi {
-  constructor(
-    readonly app: App,
-    readonly dataSource: DataSource,
-    readonly dataApi: DataApi
-  ) {}
+  constructor(readonly dataSource: DataSource, readonly dataApi: DataApi) {}
 
   addRecord(record: DataRecord, templatePath: string) {
     if (this.dataSource.includes(record.id)) {
@@ -42,7 +36,7 @@ export class ViewApi {
 
     if (oldName) {
       this.dataApi.renameField(
-        filesFromRecords(this.app, get(dataFrame).records),
+        get(dataFrame).records.map((record) => record.id),
         oldName,
         field.name
       );
@@ -52,7 +46,7 @@ export class ViewApi {
   deleteField(field: string) {
     dataFrame.deleteField(field);
     this.dataApi.deleteField(
-      filesFromRecords(this.app, get(dataFrame).records),
+      get(dataFrame).records.map((record) => record.id),
       field
     );
   }


### PR DESCRIPTION
This PR introduces a file system abstraction to be able to write tests for code that depends on Obsidian, such as data sources and IO operations.

This should not affect functionality, but should enable better test coverage going forward. Data sources have been difficult to test due to them depending on the obsidian package, which is only available when running the code inside Obsidian.

The PR adds an in-memory file system that can be used in tests.