### PR TITLE
Add place holder for new project path

### DIFF
--- a/src/modals/components/CreateProject.svelte
+++ b/src/modals/components/CreateProject.svelte
@@ -151,6 +151,7 @@
             }
           }}
           getLabel={(file) => file.path}
+          placeholder={"/"}
           width="100%"
         />
       </SettingItem>


### PR DESCRIPTION
A UI modification on `create-project-modal`, won't affect any function.

<img width="417" alt="image" src="https://user-images.githubusercontent.com/73122375/227151554-440806bc-be20-491e-9ba0-eb5c928b986c.png">
