### PR TITLE
New toolbar design

### DIFF
--- a/src/app/toolbar/ProjectSelect.svelte
+++ b/src/app/toolbar/ProjectSelect.svelte
@@ -16,6 +16,7 @@
   $: project = projects.find((project) => project.id === projectId);
 
   export let onProjectChange: (projectId: ProjectId) => void;
+  export let onProjectAdd: () => void;
 </script>
 
 <span>
@@ -40,6 +41,15 @@
       size="sm"
       on:click={(event) => {
         const menu = new Menu();
+
+        menu.addItem((item) => {
+          item
+            .setTitle($i18n.t("modals.project.create.short-title"))
+            .setIcon("folder-plus")
+            .onClick(() => {
+              onProjectAdd();
+            });
+        });
 
         menu.addItem((item) => {
           item

--- a/src/app/toolbar/ProjectSelect.svelte
+++ b/src/app/toolbar/ProjectSelect.svelte
@@ -44,15 +44,6 @@
 
         menu.addItem((item) => {
           item
-            .setTitle($i18n.t("modals.project.create.short-title"))
-            .setIcon("folder-plus")
-            .onClick(() => {
-              onProjectAdd();
-            });
-        });
-
-        menu.addItem((item) => {
-          item
             .setTitle($i18n.t("modals.project.edit.short-title"))
             .setIcon("edit")
             .onClick(() => {
@@ -105,6 +96,12 @@
       }}
     />
   {/if}
+  <IconButton
+    icon="folder-plus"
+    size="sm"
+    tooltip={$i18n.t("modals.project.create.title")}
+    on:click={() => onProjectAdd()}
+  />
 </span>
 
 <style>

--- a/src/app/toolbar/ProjectSelect.svelte
+++ b/src/app/toolbar/ProjectSelect.svelte
@@ -98,7 +98,7 @@
   {/if}
   <IconButton
     icon="folder-plus"
-    size="sm"
+    size="md"
     tooltip={$i18n.t("modals.project.create.title")}
     on:click={() => onProjectAdd()}
   />

--- a/src/app/toolbar/ProjectSelect.svelte
+++ b/src/app/toolbar/ProjectSelect.svelte
@@ -39,6 +39,7 @@
     <IconButton
       icon="more-vertical"
       size="sm"
+      tooltip={$i18n.t("toolbar.projects.options")}
       on:click={(event) => {
         const menu = new Menu();
 

--- a/src/app/toolbar/ProjectSelect.svelte
+++ b/src/app/toolbar/ProjectSelect.svelte
@@ -35,73 +35,72 @@
     placeholder={$i18n.t("toolbar.projects.none") ?? ""}
   />
 
-  {#if projects.length}
-    <IconButton
-      icon="more-vertical"
-      size="sm"
-      tooltip={$i18n.t("toolbar.projects.options")}
-      onClick={(event) => {
-        const menu = new Menu();
+  <IconButton
+    icon="more-vertical"
+    size="sm"
+    disabled={!projects.length}
+    tooltip={$i18n.t("toolbar.projects.options")}
+    onClick={(event) => {
+      const menu = new Menu();
 
-        menu.addItem((item) => {
-          item
-            .setTitle($i18n.t("modals.project.edit.short-title"))
-            .setIcon("edit")
-            .onClick(() => {
-              if (project) {
-                new CreateProjectModal(
-                  $app,
-                  $i18n.t("modals.project.edit.title"),
-                  $i18n.t("modals.project.edit.cta"),
-                  settings.updateProject,
-                  project
-                ).open();
-              }
-            });
-        });
-
-        menu.addItem((item) => {
-          item
-            .setTitle($i18n.t("modals.project.duplicate.title"))
-            .setIcon("copy")
-            .onClick(() => {
-              if (projectId) {
-                const id = settings.duplicateProject(projectId);
-                onProjectChange(id);
-              }
-            });
-        });
-
-        menu.addItem((item) => {
-          item
-            .setTitle($i18n.t("modals.project.delete.short-title"))
-            .setIcon("trash")
-            .onClick(() => {
-              new ConfirmDialogModal(
+      menu.addItem((item) => {
+        item
+          .setTitle($i18n.t("modals.project.edit.short-title"))
+          .setIcon("edit")
+          .onClick(() => {
+            if (project) {
+              new CreateProjectModal(
                 $app,
-                $i18n.t("modals.project.delete.title"),
-                $i18n.t("modals.project.delete.message", {
-                  project: project?.name ?? "",
-                }),
-                $i18n.t("modals.project.delete.cta"),
-                () => {
-                  if (projectId) {
-                    settings.deleteProject(projectId);
-                  }
-                }
+                $i18n.t("modals.project.edit.title"),
+                $i18n.t("modals.project.edit.cta"),
+                settings.updateProject,
+                project
               ).open();
-            });
-        });
+            }
+          });
+      });
 
-        menu.showAtMouseEvent(event);
-      }}
-    />
-  {/if}
+      menu.addItem((item) => {
+        item
+          .setTitle($i18n.t("modals.project.duplicate.title"))
+          .setIcon("copy")
+          .onClick(() => {
+            if (projectId) {
+              const id = settings.duplicateProject(projectId);
+              onProjectChange(id);
+            }
+          });
+      });
+
+      menu.addItem((item) => {
+        item
+          .setTitle($i18n.t("modals.project.delete.short-title"))
+          .setIcon("trash")
+          .onClick(() => {
+            new ConfirmDialogModal(
+              $app,
+              $i18n.t("modals.project.delete.title"),
+              $i18n.t("modals.project.delete.message", {
+                project: project?.name ?? "",
+              }),
+              $i18n.t("modals.project.delete.cta"),
+              () => {
+                if (projectId) {
+                  settings.deleteProject(projectId);
+                }
+              }
+            ).open();
+          });
+      });
+
+      menu.showAtMouseEvent(event);
+    }}
+  />
   <IconButton
     icon="folder-plus"
     size="md"
     tooltip={$i18n.t("modals.project.create.title")}
-    on:click={() => onProjectAdd()}
+    onClick={() => onProjectAdd()}
   />
 </span>
 

--- a/src/app/toolbar/Toolbar.svelte
+++ b/src/app/toolbar/Toolbar.svelte
@@ -130,7 +130,6 @@
     {/if}
   </div>
   <svelte:fragment slot="view-options">
-    {#if viewId}
       {@const view = projects
         .find((project) => project.id === projectId)
         ?.views?.find((view) => view.id === viewId)}
@@ -140,6 +139,7 @@
         on:click={() => {
           colorOpen = !colorOpen;
         }}
+        disabled = {!view}
       >
         <Icon name="palette" />
         Color
@@ -181,6 +181,7 @@
         on:click={() => {
           filterOpen = !filterOpen;
         }}
+        disabled = {!view}
       >
         <Icon name="filter" />
         Filter
@@ -217,6 +218,5 @@
           fields={$dataFrame.fields}
         />
       </Popover>
-    {/if}
   </svelte:fragment>
 </ViewToolbar>

--- a/src/app/toolbar/Toolbar.svelte
+++ b/src/app/toolbar/Toolbar.svelte
@@ -79,6 +79,14 @@
             settings.sortViews(projectId, viewIds);
           }
         }}
+        onViewAdd={() => {
+          if (project) {
+            new AddViewModal($app, project, (projectId, view) => {
+              settings.addView(projectId, view);
+              onViewChange(view.id);
+            }).open();
+          }
+        }}
         onViewRename={(viewId, name) => {
           if (projectId) {
             settings.renameView(projectId, viewId, name);

--- a/src/app/toolbar/Toolbar.svelte
+++ b/src/app/toolbar/Toolbar.svelte
@@ -1,19 +1,16 @@
 <script lang="ts">
-  import { Menu } from "obsidian";
   import { Button, Icon, Popover } from "obsidian-svelte";
 
   import ViewToolbar from "src/components/Layout/ViewToolbar.svelte";
   import FilterSettings from "src/components/FilterSettings/FilterSettings.svelte";
   import ColorFilterSettings from "src/components/FilterSettings/ColorFilterSettings.svelte";
-  import { createDataRecord, createProject } from "src/lib/data-api";
-  import { api } from "src/lib/stores/api";
+  import { createProject } from "src/lib/data-api";
   import { i18n } from "src/lib/stores/i18n";
   import { app } from "src/lib/stores/obsidian";
   import { dataFrame } from "src/lib/stores/dataframe";
   import { settings } from "src/lib/stores/settings";
   import { AddViewModal } from "src/modals/add-view-modal";
   import { ConfirmDialogModal } from "src/modals/confirm-dialog";
-  import { CreateNoteModal } from "src/modals/create-note-modal";
   import { CreateProjectModal } from "src/modals/create-project-modal";
   import Flair from "./Flair.svelte";
 
@@ -222,70 +219,4 @@
       </Popover>
     {/if}
   </svelte:fragment>
-
-  <Button
-    slot="right"
-    variant="primary"
-    on:click={(event) => {
-      const menu = new Menu();
-
-      menu.addItem((item) => {
-        item
-          .setTitle($i18n.t("modals.project.create.short-title"))
-          .setIcon("folder")
-          .onClick(() => {
-            new CreateProjectModal(
-              $app,
-              $i18n.t("modals.project.create.title"),
-              $i18n.t("modals.project.create.cta"),
-              (project) => {
-                settings.addProject(project);
-                projectId = project.id;
-                onProjectChange(project.id);
-              },
-              createProject()
-            ).open();
-          });
-      });
-
-      if (project) {
-        menu.addItem((item) => {
-          item
-            .setTitle($i18n.t("modals.view.create.short-title"))
-            .setIcon("table")
-            .onClick(() => {
-              if (project) {
-                new AddViewModal($app, project, (projectId, view) => {
-                  settings.addView(projectId, view);
-                  onViewChange(view.id);
-                }).open();
-              }
-            });
-        });
-        menu.addItem((item) => {
-          item
-            .setTitle($i18n.t("modals.note.create.short-title"))
-            .setIcon("file")
-            .onClick(() => {
-              if (project) {
-                new CreateNoteModal(
-                  $app,
-                  project,
-                  (name, templatePath, project) => {
-                    $api.createNote(
-                      createDataRecord(name, project),
-                      templatePath
-                    );
-                  }
-                ).open();
-              }
-            });
-        });
-      }
-      menu.showAtMouseEvent(event);
-    }}
-  >
-    {$i18n.t("toolbar.new")}
-    <Icon accent name="chevron-down" />
-  </Button>
 </ViewToolbar>

--- a/src/app/toolbar/Toolbar.svelte
+++ b/src/app/toolbar/Toolbar.svelte
@@ -130,93 +130,93 @@
     {/if}
   </div>
   <svelte:fragment slot="view-options">
-      {@const view = projects
-        .find((project) => project.id === projectId)
-        ?.views?.find((view) => view.id === viewId)}
+    {@const view = projects
+      .find((project) => project.id === projectId)
+      ?.views?.find((view) => view.id === viewId)}
 
-      <Button
-        bind:ref={colorRef}
-        on:click={() => {
-          colorOpen = !colorOpen;
+    <Button
+      bind:ref={colorRef}
+      on:click={() => {
+        colorOpen = !colorOpen;
+      }}
+      disabled={!view}
+    >
+      <Icon name="palette" />
+      Color
+      {#if view?.colors.conditions.length}
+        <Flair variant="primary">{view?.colors.conditions.length}</Flair>
+      {/if}
+    </Button>
+    <Popover
+      anchorEl={colorRef}
+      open={colorOpen}
+      onClose={() => {
+        colorOpen = false;
+      }}
+      placement="auto"
+    >
+      <ColorFilterSettings
+        filter={view?.colors ?? {
+          conditions: [],
         }}
-        disabled = {!view}
-      >
-        <Icon name="palette" />
-        Color
-        {#if view?.colors.conditions.length}
-          <Flair variant="primary">{view?.colors.conditions.length}</Flair>
-        {/if}
-      </Button>
-      <Popover
-        anchorEl={colorRef}
-        open={colorOpen}
-        onClose={() => {
-          colorOpen = false;
-        }}
-        placement="auto"
-      >
-        <ColorFilterSettings
-          filter={view?.colors ?? {
-            conditions: [],
-          }}
-          onFilterChange={(filter) => {
-            const view = projects
-              .find((project) => project.id === projectId)
-              ?.views?.find((view) => view.id === viewId);
+        onFilterChange={(filter) => {
+          const view = projects
+            .find((project) => project.id === projectId)
+            ?.views?.find((view) => view.id === viewId);
 
-            if (projectId && view) {
-              settings.updateView(
-                projectId,
-                produce(view, (draft) => {
-                  draft.colors = filter;
-                })
-              );
-            }
-          }}
-          fields={$dataFrame.fields}
-        />
-      </Popover>
-      <Button
-        bind:ref={filterRef}
-        on:click={() => {
-          filterOpen = !filterOpen;
+          if (projectId && view) {
+            settings.updateView(
+              projectId,
+              produce(view, (draft) => {
+                draft.colors = filter;
+              })
+            );
+          }
         }}
-        disabled = {!view}
-      >
-        <Icon name="filter" />
-        Filter
-        {#if view?.filter.conditions.length}
-          <Flair variant="primary">{view?.filter.conditions.length}</Flair>
-        {/if}
-      </Button>
-      <Popover
-        anchorEl={filterRef}
-        open={filterOpen}
-        onClose={() => {
-          filterOpen = false;
+        fields={$dataFrame.fields}
+      />
+    </Popover>
+    <Button
+      bind:ref={filterRef}
+      on:click={() => {
+        filterOpen = !filterOpen;
+      }}
+      disabled={!view}
+    >
+      <Icon name="filter" />
+      Filter
+      {#if view?.filter.conditions.length}
+        <Flair variant="primary">{view?.filter.conditions.length}</Flair>
+      {/if}
+    </Button>
+    <Popover
+      anchorEl={filterRef}
+      open={filterOpen}
+      onClose={() => {
+        filterOpen = false;
+      }}
+      placement="auto"
+    >
+      <FilterSettings
+        filter={view?.filter ?? {
+          conditions: [],
         }}
-        placement="auto"
-      >
-        <FilterSettings
-          filter={view?.filter ?? {
-            conditions: [],
-          }}
-          onFilterChange={(filter) => {
-            const view = projects
-              .find((project) => project.id === projectId)
-              ?.views?.find((view) => view.id === viewId);
+        onFilterChange={(filter) => {
+          const view = projects
+            .find((project) => project.id === projectId)
+            ?.views?.find((view) => view.id === viewId);
 
-            if (projectId && view) {
-              settings.updateView(
-                projectId,
-                produce(view, (draft) => {
-                  draft.filter = filter;
-                })
-              );
-            }
-          }}
-          fields={$dataFrame.fields}
-        />
-      </Popover>
+          if (projectId && view) {
+            settings.updateView(
+              projectId,
+              produce(view, (draft) => {
+                draft.filter = filter;
+              })
+            );
+          }
+        }}
+        fields={$dataFrame.fields}
+      />
+    </Popover>
   </svelte:fragment>
 </ViewToolbar>

--- a/src/app/toolbar/Toolbar.svelte
+++ b/src/app/toolbar/Toolbar.svelte
@@ -65,7 +65,24 @@
     {/if}
   </svelte:fragment>
 
-  <ProjectSelect slot="left" {projectId} {projects} {onProjectChange} />
+  <ProjectSelect
+    slot="left"
+    {projectId}
+    {projects}
+    {onProjectChange}
+    onProjectAdd={() =>
+      new CreateProjectModal(
+        $app,
+        $i18n.t("modals.project.create.title"),
+        $i18n.t("modals.project.create.cta"),
+        (project) => {
+          settings.addProject(project);
+          projectId = project.id;
+          onProjectChange(project.id);
+        },
+        createProject()
+      ).open()}
+  />
 
   <div slot="middle">
     {#if project}

--- a/src/app/toolbar/ViewSelect.svelte
+++ b/src/app/toolbar/ViewSelect.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { customViews } from "src/lib/stores/custom-views";
   import type { ViewDefinition, ViewId } from "src/settings/settings";
+  import { IconButton } from "obsidian-svelte";
 
   import ViewItem from "./ViewItem.svelte";
   import ViewItemList from "./ViewItemList.svelte";
@@ -9,6 +10,7 @@
   export let views: ViewDefinition[];
   export let onViewChange: (viewId: ViewId) => void;
   export let onViewDelete: (viewId: ViewId) => void;
+  export let onViewAdd: () => void;
   export let onViewDuplicate: (viewId: ViewId) => void;
   export let onViewRename: (viewId: ViewId, name: string) => void;
   export let onViewSort: (viewIds: ViewId[]) => void;
@@ -48,4 +50,11 @@
       />
     {/each}
   {/key}
+  <IconButton
+    icon="plus"
+    size="sm"
+    on:click={() => {
+      onViewAdd();
+    }}
+  />
 </ViewItemList>

--- a/src/app/toolbar/ViewSelect.svelte
+++ b/src/app/toolbar/ViewSelect.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { customViews } from "src/lib/stores/custom-views";
   import type { ViewDefinition, ViewId } from "src/settings/settings";
-  import { IconButton } from "obsidian-svelte";
+  import { Icon } from "obsidian-svelte";
+  import { i18n } from "src/lib/stores/i18n";
 
   import ViewItem from "./ViewItem.svelte";
   import ViewItemList from "./ViewItemList.svelte";
@@ -50,11 +51,36 @@
       />
     {/each}
   {/key}
-  <IconButton
-    icon="plus"
-    size="sm"
-    on:click={() => {
+  <div
+    on:mouseup={() => {
       onViewAdd();
     }}
-  />
+  >
+    <Icon
+      name="plus"
+      size="sm"
+      tooltip={views.length ? $i18n.t("toolbar.view.add") : ""}
+    />
+    {#if !views.length}
+      {$i18n.t("toolbar.view.add")}
+    {/if}
+  </div>
 </ViewItemList>
+
+<style>
+  div {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+
+    height: 1.8rem;
+    padding: 0 4px;
+    min-width: min-content;
+
+    font-size: var(--font-ui-small);
+    border-radius: var(--radius-s);
+  }
+  div:hover {
+    background-color: var(--background-modifier-hover);
+  }
+</style>

--- a/src/app/toolbar/ViewSelect.svelte
+++ b/src/app/toolbar/ViewSelect.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { customViews } from "src/lib/stores/custom-views";
   import type { ViewDefinition, ViewId } from "src/settings/settings";
-  import { Icon } from "obsidian-svelte";
+  import { Icon, IconButton } from "obsidian-svelte";
   import { i18n } from "src/lib/stores/i18n";
 
   import ViewItem from "./ViewItem.svelte";
@@ -51,20 +51,25 @@
       />
     {/each}
   {/key}
-  <div
-    on:mouseup={() => {
-      onViewAdd();
-    }}
-  >
-    <Icon
-      name="plus"
+  {#if views.length}
+    <IconButton
+      icon="plus"
       size="sm"
-      tooltip={views.length ? $i18n.t("toolbar.view.add") : ""}
+      on:click={() => {
+        onViewAdd();
+      }}
+      tooltip={$i18n.t("toolbar.view.add")}
     />
-    {#if !views.length}
+  {:else}
+    <div
+      on:mouseup={() => {
+        onViewAdd();
+      }}
+    >
+      <Icon name="plus" size="sm" />
       {$i18n.t("toolbar.view.add")}
-    {/if}
-  </div>
+    </div>
+  {/if}
 </ViewItemList>
 
 <style>

--- a/src/app/toolbar/ViewSelect.svelte
+++ b/src/app/toolbar/ViewSelect.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { customViews } from "src/lib/stores/custom-views";
   import type { ViewDefinition, ViewId } from "src/settings/settings";
-  import { Icon, IconButton } from "obsidian-svelte";
+  import { Icon, Button, IconButton } from "obsidian-svelte";
   import { i18n } from "src/lib/stores/i18n";
 
   import ViewItem from "./ViewItem.svelte";
@@ -64,14 +64,14 @@
     />
   </span>
 {:else}
-  <div
-    on:mouseup={() => {
+  <Button
+    on:click={() => {
       onViewAdd();
     }}
   >
     <Icon name="plus" size="sm" />
     {$i18n.t("toolbar.view.add")}
-  </div>
+  </Button>
 {/if}
 
 <style>
@@ -79,22 +79,5 @@
     display: inline-flex;
     align-items: center;
     gap: 4px;
-  }
-
-  div {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-
-    height: 1.8rem;
-    padding: 0 4px;
-    min-width: min-content;
-
-    font-size: var(--font-ui-small);
-    border-radius: var(--radius-s);
-  }
-
-  div:hover {
-    background-color: var(--background-modifier-hover);
   }
 </style>

--- a/src/app/toolbar/ViewSelect.svelte
+++ b/src/app/toolbar/ViewSelect.svelte
@@ -22,36 +22,38 @@
   }
 </script>
 
-<ViewItemList onSort={onViewSort}>
-  {#key views}
-    {#each views as v (v.id)}
-      <ViewItem
-        id={v.id}
-        active={viewId === v.id}
-        label={v.name}
-        icon={iconFromViewType(v.type)}
-        on:mousedown={() => onViewChange(v.id)}
-        on:rename={({ detail: name }) => {
-          onViewRename(v.id, name);
-        }}
-        on:delete={() => {
-          onViewDelete(v.id);
-        }}
-        on:duplicate={() => {
-          onViewDuplicate(v.id);
-        }}
-        onValidate={(name) => {
-          // Check if view has it's original name.
-          if (name === v.name) {
-            return true;
-          }
+{#if views.length}
+  <span>
+    <ViewItemList onSort={onViewSort}>
+      {#key views}
+        {#each views as v (v.id)}
+          <ViewItem
+            id={v.id}
+            active={viewId === v.id}
+            label={v.name}
+            icon={iconFromViewType(v.type)}
+            on:mousedown={() => onViewChange(v.id)}
+            on:rename={({ detail: name }) => {
+              onViewRename(v.id, name);
+            }}
+            on:delete={() => {
+              onViewDelete(v.id);
+            }}
+            on:duplicate={() => {
+              onViewDuplicate(v.id);
+            }}
+            onValidate={(name) => {
+              // Check if view has it's original name.
+              if (name === v.name) {
+                return true;
+              }
 
-          return name !== "" && !viewExists(name);
-        }}
-      />
-    {/each}
-  {/key}
-  {#if views.length}
+              return name !== "" && !viewExists(name);
+            }}
+          />
+        {/each}
+      {/key}
+    </ViewItemList>
     <IconButton
       icon="plus"
       size="sm"
@@ -60,19 +62,25 @@
       }}
       tooltip={$i18n.t("toolbar.view.add")}
     />
-  {:else}
-    <div
-      on:mouseup={() => {
-        onViewAdd();
-      }}
-    >
-      <Icon name="plus" size="sm" />
-      {$i18n.t("toolbar.view.add")}
-    </div>
-  {/if}
-</ViewItemList>
+  </span>
+{:else}
+  <div
+    on:mouseup={() => {
+      onViewAdd();
+    }}
+  >
+    <Icon name="plus" size="sm" />
+    {$i18n.t("toolbar.view.add")}
+  </div>
+{/if}
 
 <style>
+  span {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
   div {
     display: inline-flex;
     align-items: center;
@@ -85,6 +93,7 @@
     font-size: var(--font-ui-small);
     border-radius: var(--radius-s);
   }
+
   div:hover {
     background-color: var(--background-modifier-hover);
   }

--- a/src/app/toolbar/ViewSelect.svelte
+++ b/src/app/toolbar/ViewSelect.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { customViews } from "src/lib/stores/custom-views";
   import type { ViewDefinition, ViewId } from "src/settings/settings";
+  import { Icon, IconButton } from "obsidian-svelte";
   import { i18n } from "src/lib/stores/i18n";
 
   import ViewItem from "./ViewItem.svelte";
@@ -63,14 +64,14 @@
     />
   </span>
 {:else}
-  <Button
-    on:click={() => {
+  <div
+    on:mouseup={() => {
       onViewAdd();
     }}
   >
     <Icon name="plus" size="sm" />
     {$i18n.t("toolbar.view.add")}
-  </Button>
+  </div>
 {/if}
 
 <style>
@@ -78,5 +79,22 @@
     display: inline-flex;
     align-items: center;
     gap: 4px;
+  }
+
+  div {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+
+    height: 1.8rem;
+    padding: 0 4px;
+    min-width: min-content;
+
+    font-size: var(--font-ui-small);
+    border-radius: var(--radius-s);
+  }
+
+  div:hover {
+    background-color: var(--background-modifier-hover);
   }
 </style>

--- a/src/app/toolbar/ViewSelect.svelte
+++ b/src/app/toolbar/ViewSelect.svelte
@@ -57,7 +57,7 @@
     <IconButton
       icon="plus"
       size="sm"
-      on:click={() => {
+      onClick={() => {
         onViewAdd();
       }}
       tooltip={$i18n.t("toolbar.view.add")}
@@ -65,6 +65,7 @@
   </span>
 {:else}
   <Button
+    variant="plain"
     on:click={() => {
       onViewAdd();
     }}

--- a/src/app/toolbar/ViewSelect.svelte
+++ b/src/app/toolbar/ViewSelect.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { customViews } from "src/lib/stores/custom-views";
   import type { ViewDefinition, ViewId } from "src/settings/settings";
-  import { Icon, IconButton } from "obsidian-svelte";
   import { i18n } from "src/lib/stores/i18n";
 
   import ViewItem from "./ViewItem.svelte";
@@ -64,14 +63,14 @@
     />
   </span>
 {:else}
-  <div
-    on:mouseup={() => {
+  <Button
+    on:click={() => {
       onViewAdd();
     }}
   >
     <Icon name="plus" size="sm" />
     {$i18n.t("toolbar.view.add")}
-  </div>
+  </Button>
 {/if}
 
 <style>
@@ -79,22 +78,5 @@
     display: inline-flex;
     align-items: center;
     gap: 4px;
-  }
-
-  div {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-
-    height: 1.8rem;
-    padding: 0 4px;
-    min-width: min-content;
-
-    font-size: var(--font-ui-small);
-    border-radius: var(--radius-s);
-  }
-
-  div:hover {
-    background-color: var(--background-modifier-hover);
   }
 </style>

--- a/src/lib/stores/i18n.ts
+++ b/src/lib/stores/i18n.ts
@@ -275,6 +275,7 @@ i18next.init({
           },
           projects: {
             none: "No projects",
+            options: "More optiopns",
           },
         },
         errors: {

--- a/src/views/Board/components/Board/BoardColumn.svelte
+++ b/src/views/Board/components/Board/BoardColumn.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Button, Typography } from "obsidian-svelte";
+  import { Button, Typography, Icon } from "obsidian-svelte";
   import { i18n } from "src/lib/stores/i18n";
 
   import { type DataRecord, type DataField, DataFieldType } from "src/lib/data";
@@ -88,6 +88,7 @@
   {#if !readonly}
     <div class="column-section">
       <Button variant="plain" on:click={() => onRecordAdd()}>
+        <Icon name="plus" />
         {$i18n.t("views.board.note.add")}
       </Button>
     </div>

--- a/src/views/Gallery/GalleryView.svelte
+++ b/src/views/Gallery/GalleryView.svelte
@@ -22,10 +22,12 @@
     type DataFrame,
     type DataRecord,
   } from "src/lib/data";
+  import { createDataRecord } from "src/lib/data-api";
   import { i18n } from "src/lib/stores/i18n";
   import { app } from "src/lib/stores/obsidian";
   import type { ViewApi } from "src/lib/view-api";
   import CenterBox from "src/modals/components/CenterBox.svelte";
+  import { CreateNoteModal } from "src/modals/create-note-modal";
   import { EditNoteModal } from "src/modals/edit-note-modal";
   import { fieldToSelectableValue } from "src/views/helpers";
   import { getDisplayName } from "../Board/components/Board/board-helpers";
@@ -37,7 +39,9 @@
   import { parseObsidianLink } from "./helpers";
   import { GallerySettingsModal } from "./settings/settings-modal";
   import type { GalleryConfig } from "./types";
+  import type { ProjectDefinition } from "src/settings/settings";
 
+  export let project: ProjectDefinition;
   export let frame: DataFrame;
   export let config: GalleryConfig | undefined;
   export let onConfigChange: (config: GalleryConfig) => void;
@@ -227,6 +231,19 @@
               </CardContent>
             </Card>
           {/each}
+          <IconButton
+            icon="plus"
+            size="lg"
+            on:click={() => {
+              new CreateNoteModal(
+                $app,
+                project,
+                (name, templatePath, project) => {
+                  api.addRecord(createDataRecord(name, project), templatePath);
+                }
+              ).open();
+            }}
+          />
         </Grid>
       </div>
     {:else}

--- a/src/views/Gallery/gallery-view.ts
+++ b/src/views/Gallery/gallery-view.ts
@@ -31,6 +31,7 @@ export class GalleryView extends ProjectView<GalleryConfig> {
       props: {
         frame: { fields: [], records: [] },
         api: props.viewApi,
+        project: props.project,
         config: props.config,
         onConfigChange: props.saveConfig,
         getRecordColor: props.getRecordColor,


### PR DESCRIPTION
This is a demo version ready for review. Related to issue #401 

## Modifications

### Unify add-note UI in Board view

Provide a "plus" icon in front of the button text.

<img width="631" alt="image" src="https://user-images.githubusercontent.com/73122375/227164144-59103fdf-158e-4487-a0f4-5208230f60a5.png">

### Allow adding notes in Gallery view

There are some problems when the adding card/button owns a new line solely. But I like the flexible feeling of the original Grid component, rather than writing a new one.

https://user-images.githubusercontent.com/73122375/227164493-6bdc6187-029a-4d1d-9d5c-74c8510d13d3.mp4

### Allow adding views in view-select

<img width="960" alt="image" src="https://user-images.githubusercontent.com/73122375/227166079-c66959bd-3004-4e4d-aaa0-4949c4acc11c.png">

### Allow creating new projects in project-select

![image](https://user-images.githubusercontent.com/73122375/227165853-93988a69-985d-4a96-b83b-fe7eff7338b7.png)



