### PR TITLE
Handle filters with empty 'enabled' field

### DIFF
--- a/src/app/View.svelte
+++ b/src/app/View.svelte
@@ -76,7 +76,7 @@
   function getRecordColor(record: DataRecord): string | null {
     const colorFilter = view.colors ?? { conditions: [] };
     for (const cond of colorFilter.conditions) {
-      if (cond.condition.enabled) {
+      if (cond.condition?.enabled ?? true) {
         if (matchesCondition(cond.condition, record)) {
           return cond.color;
         }

--- a/src/app/filter-functions.ts
+++ b/src/app/filter-functions.ts
@@ -52,7 +52,7 @@ export function matchesFilterConditions(
   record: DataRecord
 ) {
   const validConds = filter.conditions.filter((cond) => {
-    return cond.enabled;
+    return cond?.enabled ?? true;
   });
   return validConds.every((cond) => matchesCondition(cond, record));
 }

--- a/src/components/FilterSettings/ColorFilterSettings.svelte
+++ b/src/components/FilterSettings/ColorFilterSettings.svelte
@@ -237,7 +237,7 @@
         {/if}
       {/if}
       <Checkbox
-        checked={condition.condition.enabled}
+        checked={condition.condition?.enabled ?? true}
         on:check={handleStatusChange(i)}
       />
       <IconButton icon="trash" onClick={handleConditionRemove(i)} />

--- a/src/components/FilterSettings/FilterSettings.svelte
+++ b/src/components/FilterSettings/FilterSettings.svelte
@@ -193,7 +193,10 @@
           />
         {/if}
       {/if}
-      <Checkbox checked={condition.enabled} on:check={handleStatusChange(i)} />
+      <Checkbox
+        checked={condition?.enabled ?? true}
+        on:check={handleStatusChange(i)}
+      />
       <IconButton icon="trash" onClick={handleConditionRemove(i)} />
     </HorizontalGroup>
   {/each}


### PR DESCRIPTION
may fix #537 

Set default as `true`, as the filters are supposed to still work after updating.

The problem here is quite similar to #282 and its fix in #286. This is caused by adding a new required filed in setting, but failed to support empty field value.