### PR TITLE
Table: Enable Add note button for Dataview projects

### DIFF
--- a/src/views/Table/components/DataGrid/DataGrid.svelte
+++ b/src/views/Table/components/DataGrid/DataGrid.svelte
@@ -234,12 +234,10 @@
   {/each}
   <GridCellGroup index={sortedRows.length + 2}>
     <span style={`width: ${60 + (sortedColumns[0]?.width ?? 0)}`}>
-      {#if !readonly}
-        <Button variant="plain" on:click={() => onRowAdd()}>
-          <Icon name="plus" />
-          {t("components.data-grid.row.add")}
-        </Button>
-      {/if}
+      <Button variant="plain" on:click={() => onRowAdd()}>
+        <Icon name="plus" />
+        {t("components.data-grid.row.add")}
+      </Button>
     </span>
   </GridCellGroup>
 </div>


### PR DESCRIPTION
With the new "Location for new notes" setting, we should be able to enable Add note for the table view.

Note that Board and Calendar views can't support this, as they need to add metadata to the note, whereas Table and Gallery don't.