### PR TITLE
Add setting to configure block and flow sequences

### DIFF
--- a/src/lib/dataApi.ts
+++ b/src/lib/dataApi.ts
@@ -139,7 +139,10 @@ export function doUpdateRecord(
       );
     }),
     E.chain((updated) =>
-      encodeFrontMatter(data, updated, getDefaultStringType())
+      encodeFrontMatter(data, updated, {
+        defaultStringType: getDefaultStringType(),
+        collectionStyle: getCollectionStyle(),
+      })
     )
   );
 }
@@ -153,7 +156,10 @@ export function doDeleteField(data: string, field: string) {
       [field]: undefined,
     })),
     E.chain((frontmatter) =>
-      encodeFrontMatter(data, frontmatter, getDefaultStringType())
+      encodeFrontMatter(data, frontmatter, {
+        defaultStringType: getDefaultStringType(),
+        collectionStyle: getCollectionStyle(),
+      })
     )
   );
 }
@@ -172,7 +178,10 @@ export function doRenameField(
       [from]: undefined,
     })),
     E.chain((frontmatter) =>
-      encodeFrontMatter(data, frontmatter, getDefaultStringType())
+      encodeFrontMatter(data, frontmatter, {
+        defaultStringType: getDefaultStringType(),
+        collectionStyle: getCollectionStyle(),
+      })
     )
   );
 }
@@ -215,6 +224,10 @@ export function createDataRecord(
   };
 }
 
-function getDefaultStringType() {
-  return get(settings).preferences?.frontmatter?.quoteStrings ?? "PLAIN";
+function getDefaultStringType(): "PLAIN" | "QUOTE_DOUBLE" {
+  return get(settings).preferences.frontmatter.quoteStrings;
+}
+
+function getCollectionStyle(): "block" | "flow" {
+  return get(settings).preferences.frontmatter.collectionStyle;
 }

--- a/src/lib/filesystem/filesystem.ts
+++ b/src/lib/filesystem/filesystem.ts
@@ -1,7 +1,3 @@
-import { either } from "fp-ts";
-import produce from "immer";
-import { encodeFrontMatter, decodeFrontMatter } from "../metadata";
-
 export abstract class IFile {
   abstract get basename(): string;
   abstract get path(): string;
@@ -10,38 +6,6 @@ export abstract class IFile {
   abstract read(): Promise<string>;
   abstract delete(): Promise<void>;
   abstract readTags(): Set<string>;
-
-  async readValue(field: string): Promise<any> {
-    const values = await this.readValues();
-
-    return values[field];
-  }
-
-  async writeValue(field: string, value: any): Promise<void> {
-    this.writeValues(
-      produce(await this.readValues(), (draft) => {
-        draft[field] = value;
-      })
-    );
-  }
-
-  async readValues(): Promise<Record<string, any>> {
-    const data = await this.read();
-
-    const values = decodeFrontMatter(data);
-
-    return either.isRight(values) ? values.right : {};
-  }
-
-  async writeValues(values: Record<string, any>): Promise<void> {
-    const data = await this.read();
-
-    const updatedData = encodeFrontMatter(data, values, "PLAIN");
-
-    if (either.isRight(updatedData)) {
-      this.write(updatedData.right);
-    }
-  }
 }
 
 export interface IFileSystem {

--- a/src/lib/metadata/encode.test.ts
+++ b/src/lib/metadata/encode.test.ts
@@ -15,7 +15,7 @@ describe("encodeFrontMatter", () => {
           title5: "Title-",
           title6: "-Title",
         },
-        "PLAIN"
+        { defaultStringType: "PLAIN", collectionStyle: "block" }
       )
     ).toStrictEqual(
       E.right(`---
@@ -41,10 +41,8 @@ status: In progress
 
 # My title
 `,
-        {
-          status: "Done",
-        },
-        "PLAIN"
+        { status: "Done" },
+        { defaultStringType: "PLAIN", collectionStyle: "block" }
       )
     ).toStrictEqual(
       E.right(`
@@ -68,10 +66,8 @@ due: 1979-01-01
 
 # My title
 `,
-        {
-          status: "Done",
-        },
-        "PLAIN"
+        { status: "Done" },
+        { defaultStringType: "PLAIN", collectionStyle: "block" }
       )
     ).toStrictEqual(
       E.right(`
@@ -92,7 +88,7 @@ due: 1979-01-01
         {
           status: null,
         },
-        "PLAIN"
+        { defaultStringType: "PLAIN", collectionStyle: "block" }
       )
     ).toStrictEqual(
       E.right(`---
@@ -121,7 +117,7 @@ test: 4
           bar: undefined,
           baz: null,
         },
-        "PLAIN"
+        { defaultStringType: "PLAIN", collectionStyle: "block" }
       )
     ).toStrictEqual(
       E.right(`

--- a/src/lib/metadata/encode.ts
+++ b/src/lib/metadata/encode.ts
@@ -2,6 +2,11 @@ import { either as E, function as F } from "fp-ts";
 import { stringify } from "yaml";
 import { parseYaml } from "./decode";
 
+export type EncodingOptions = {
+  collectionStyle: "block" | "flow";
+  defaultStringType: "PLAIN" | "QUOTE_DOUBLE";
+};
+
 /**
  * encodeFrontMatter updates the front matter of a note.
  *
@@ -12,7 +17,7 @@ import { parseYaml } from "./decode";
 export function encodeFrontMatter(
   data: string,
   frontmatter: Record<string, any>,
-  defaultStringType: "PLAIN" | "QUOTE_DOUBLE"
+  options: EncodingOptions
 ): E.Either<Error, string> {
   const delim = "---";
 
@@ -27,7 +32,7 @@ export function encodeFrontMatter(
     E.map((existing) => Object.assign({}, existing, frontmatter)),
     E.map((fm) => {
       if (Object.entries(fm).length) {
-        const d = stringifyYaml(fm, defaultStringType);
+        const d = stringifyYaml(fm, options);
 
         return hasFrontMatter
           ? data.slice(0, startPosition + 1) + d + data.slice(endPosition)
@@ -47,14 +52,19 @@ export function encodeFrontMatter(
  */
 export function stringifyYaml(
   value: any,
-  defaultStringType: "PLAIN" | "QUOTE_DOUBLE" = "PLAIN"
+  options: EncodingOptions = {
+    collectionStyle: "block",
+    defaultStringType: "PLAIN",
+  }
 ): string {
   return F.pipe(value, (value) =>
     stringify(value, {
       lineWidth: 0,
       nullStr: "",
-      defaultStringType: defaultStringType,
+      defaultStringType: options.defaultStringType,
       defaultKeyType: "PLAIN",
+      collectionStyle: options.collectionStyle,
+      flowCollectionPadding: false,
     })
   );
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -79,12 +79,35 @@ export class ProjectsSettingTab extends PluginSettingTab {
             save({
               ...preferences,
               frontmatter: {
+                ...preferences.frontmatter,
                 quoteStrings: value,
               },
             });
           }
         })
     );
+
+    new Setting(containerEl)
+      .setName("Collection style")
+      .addDropdown((dropdown) =>
+        dropdown
+          .addOptions({
+            block: "Block sequence",
+            flow: "Flow sequence",
+          })
+          .setValue(preferences.frontmatter.collectionStyle)
+          .onChange((value) => {
+            if (value === "block" || value === "flow") {
+              save({
+                ...preferences,
+                frontmatter: {
+                  ...preferences.frontmatter,
+                  collectionStyle: value,
+                },
+              });
+            }
+          })
+      );
 
     new Setting(containerEl)
       .setName("Commands")

--- a/src/settings/base/settings.ts
+++ b/src/settings/base/settings.ts
@@ -118,6 +118,7 @@ export type ProjectsPluginPreferences = {
   readonly projectSizeLimit: number;
   readonly frontmatter: {
     readonly quoteStrings: "PLAIN" | "QUOTE_DOUBLE";
+    readonly collectionStyle: "block" | "flow";
   };
   readonly commands: ShowCommand[];
   readonly linkBehavior: LinkBehavior;

--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -112,6 +112,7 @@ const v1demo: v1.ProjectsPluginSettings<
   preferences: {
     frontmatter: {
       quoteStrings: "PLAIN",
+      collectionStyle: "block",
     },
     projectSizeLimit: 1000,
     commands: [],
@@ -226,6 +227,7 @@ const v2demo: v2.ProjectsPluginSettings<
     projectSizeLimit: 1000,
     frontmatter: {
       quoteStrings: "PLAIN",
+      collectionStyle: "block",
     },
     commands: [],
     linkBehavior: "open-editor",

--- a/src/settings/v1/settings.ts
+++ b/src/settings/v1/settings.ts
@@ -38,6 +38,7 @@ export const DEFAULT_SETTINGS: ProjectsPluginSettings<
     projectSizeLimit: 1000,
     frontmatter: {
       quoteStrings: "PLAIN",
+      collectionStyle: "block",
     },
     commands: [],
     linkBehavior: "open-editor",

--- a/src/settings/v2/settings.ts
+++ b/src/settings/v2/settings.ts
@@ -81,6 +81,7 @@ export const DEFAULT_SETTINGS: ProjectsPluginSettings<
     projectSizeLimit: 1000,
     frontmatter: {
       quoteStrings: "PLAIN",
+      collectionStyle: "block",
     },
     commands: [],
     linkBehavior: "open-editor",
@@ -141,6 +142,7 @@ export const DEFAULT_PREFERENCES: ProjectsPluginPreferences = {
   projectSizeLimit: 1000,
   frontmatter: {
     quoteStrings: "PLAIN",
+    collectionStyle: "block",
   },
   commands: [],
   linkBehavior: "open-editor",


### PR DESCRIPTION
**BLOCKER**: The YAML library doesn't seem to let me configure the collection style for maps and sequences separately. If I set `collectionStyle` to `flow`, it adds unnecessary braces to objects.

Fixes #437 