### PR TITLE
Allow move Projects main view to new window in tab header.

### DIFF
--- a/src/lib/stores/i18n.ts
+++ b/src/lib/stores/i18n.ts
@@ -32,6 +32,11 @@ i18next.init({
               title: "Create project in folder",
             },
           },
+          tabHeader: {
+            newWindow: {
+              title: "Move to new window",
+            },
+          },
         },
         modals: {
           project: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -220,6 +220,18 @@ export default class ProjectsPlugin extends Plugin {
   }
 
   /**
+   * this moves the main Projects view to a new window.
+   * */
+  async moveToNewWindow() {
+    const existingLeaves =
+      this.app.workspace.getLeavesOfType(VIEW_TYPE_PROJECTS);
+
+    if (existingLeaves[0]) {
+      this.app.workspace.moveLeafToPopout(existingLeaves[0]);
+    }
+  }
+
+  /**
    * getOrCreateLeaf returns a new leaf, or returns an existing leaf if
    * Projects is already open.
    */

--- a/src/main.ts
+++ b/src/main.ts
@@ -220,18 +220,6 @@ export default class ProjectsPlugin extends Plugin {
   }
 
   /**
-   * this moves the main Projects view to a new window.
-   * */
-  async moveToNewWindow() {
-    const existingLeaves =
-      this.app.workspace.getLeavesOfType(VIEW_TYPE_PROJECTS);
-
-    if (existingLeaves[0]) {
-      this.app.workspace.moveLeafToPopout(existingLeaves[0]);
-    }
-  }
-
-  /**
    * getOrCreateLeaf returns a new leaf, or returns an existing leaf if
    * Projects is already open.
    */

--- a/src/view.ts
+++ b/src/view.ts
@@ -64,7 +64,7 @@ export class ProjectsView extends ItemView {
           .onClick(() => {
             this.plugin.moveToNewWindow();
           })
-          .setSection("open");
+          .setSection("open"); // https://docs.obsidian.md/Reference/TypeScript+API/MenuItem/setSection
       });
       return;
     }

--- a/src/view.ts
+++ b/src/view.ts
@@ -2,10 +2,13 @@ import {
   Plugin,
   ItemView,
   WorkspaceLeaf,
+  type Menu,
   type ViewStateResult,
 } from "obsidian";
+import { get } from "svelte/store";
 
 import App from "src/ui/app/App.svelte";
+import { i18n } from "./lib/stores/i18n";
 import { customViews } from "src/lib/stores/customViews";
 import { view } from "src/lib/stores/obsidian";
 import { BoardView } from "src/ui/views/Board";
@@ -49,6 +52,26 @@ export class ProjectsView extends ItemView {
 
   getIcon() {
     return "layout";
+  }
+
+  onPaneMenu(menu: Menu, source: "more-options" | "tab-header" | string) {
+    if (source == "tab-header") {
+      super.onPaneMenu(menu, source);
+      menu
+        .addItem((item) => {
+          item
+            .setTitle(get(i18n).t("menus.tabHeader.newWindow.title"))
+            .setIcon("maximize")
+            .onClick(() => {
+              this.plugin.moveToNewWindow();
+            });
+        })
+        .addSeparator();
+      return;
+    }
+
+    // In other cases, keep the original behavior
+    super.onPaneMenu(menu, source);
   }
 
   async onload() {

--- a/src/view.ts
+++ b/src/view.ts
@@ -68,7 +68,7 @@ export class ProjectsView extends ItemView {
               this.app.workspace.moveLeafToPopout(existingLeaves[0]);
             }
           })
-          .setSection("open"); // https://docs.obsidian.md/Reference/TypeScript+API/MenuItem/setSection
+          .setSection("open");
       });
       return;
     }

--- a/src/view.ts
+++ b/src/view.ts
@@ -62,7 +62,11 @@ export class ProjectsView extends ItemView {
           .setTitle(get(i18n).t("menus.tabHeader.newWindow.title"))
           .setIcon("maximize")
           .onClick(() => {
-            this.plugin.moveToNewWindow();
+            const existingLeaves =
+              this.app.workspace.getLeavesOfType(VIEW_TYPE_PROJECTS);
+            if (existingLeaves[0]) {
+              this.app.workspace.moveLeafToPopout(existingLeaves[0]);
+            }
           })
           .setSection("open"); // https://docs.obsidian.md/Reference/TypeScript+API/MenuItem/setSection
       });

--- a/src/view.ts
+++ b/src/view.ts
@@ -2,7 +2,7 @@ import {
   Plugin,
   ItemView,
   WorkspaceLeaf,
-  type Menu,
+  Menu,
   type ViewStateResult,
 } from "obsidian";
 import { get } from "svelte/store";
@@ -57,16 +57,15 @@ export class ProjectsView extends ItemView {
   onPaneMenu(menu: Menu, source: "more-options" | "tab-header" | string) {
     if (source == "tab-header") {
       super.onPaneMenu(menu, source);
-      menu
-        .addItem((item) => {
-          item
-            .setTitle(get(i18n).t("menus.tabHeader.newWindow.title"))
-            .setIcon("maximize")
-            .onClick(() => {
-              this.plugin.moveToNewWindow();
-            });
-        })
-        .addSeparator();
+      menu.addItem((item) => {
+        item
+          .setTitle(get(i18n).t("menus.tabHeader.newWindow.title"))
+          .setIcon("maximize")
+          .onClick(() => {
+            this.plugin.moveToNewWindow();
+          })
+          .setSection("open");
+      });
       return;
     }
 


### PR DESCRIPTION
Fixes #633 

- [x] Prototype submitted, July 28, 2023
- [x] Remove unnecessary separator line in the menu, Reference: https://github.com/zapthedingbat/drawio-obsidian `DiagramPlugin.ts` (Finally solved by MenuItem method setSection())
- [x] Move the function in `main.ts` to `view.ts`

Preview:
<img width="357" alt="image" src="https://github.com/marcusolsson/obsidian-projects/assets/73122375/29415b5e-d462-4617-8838-5e9c2b8865c7">
