### PR TITLE
Accept view rename by click outside

### DIFF
--- a/src/ui/app/toolbar/ViewItem.svelte
+++ b/src/ui/app/toolbar/ViewItem.svelte
@@ -80,6 +80,10 @@
         if (event.key === "Enter") {
           editing = false;
 
+          if (fallback == label) {
+            return;
+          }
+
           if (!error) {
             fallback = label;
 
@@ -91,19 +95,18 @@
         if (event.key === "Escape") {
           editing = false;
 
-          // After executed, the label value read by on:blur
-          // is set to the original value, to prevent rename
           rollback();
         }
       }}
       on:blur={() => {
-        if (!error) {
-          // avoid unnessesary call
-          if (fallback != label) {
-            fallback = label;
+        if (fallback == label) {
+          return;
+        }
 
-            dispatch("rename", label);
-          }
+        if (!error) {
+          fallback = label;
+
+          dispatch("rename", label);
         } else {
           rollback();
         }

--- a/src/ui/app/toolbar/ViewItem.svelte
+++ b/src/ui/app/toolbar/ViewItem.svelte
@@ -1,11 +1,6 @@
 <script lang="ts">
   import { Menu } from "obsidian";
-  import {
-    Icon,
-    IconButton,
-    TextInput,
-    useClickOutside,
-  } from "obsidian-svelte";
+  import { Icon, IconButton, TextInput } from "obsidian-svelte";
   import { createEventDispatcher } from "svelte";
 
   /**
@@ -67,18 +62,8 @@
   data-id={id}
   class:active
   class:error
-  on:blur={() => {
-    editing = false;
-
-    rollback();
-  }}
   on:dblclick={() => (editing = true)}
   on:mousedown
-  use:useClickOutside={() => {
-    editing = false;
-
-    rollback();
-  }}
 >
   {#if icon}
     <Icon name={icon} />
@@ -102,6 +87,22 @@
           } else {
             rollback();
           }
+        }
+        if (event.key === "Escape") {
+          editing = false;
+
+          // After executed, the label value read by on:blur
+          // is set to original value, to prevent rename
+          rollback();
+        }
+      }}
+      on:blur={() => {
+        if (!error) {
+          fallback = label;
+
+          dispatch("rename", label);
+        } else {
+          rollback();
         }
       }}
     />

--- a/src/ui/app/toolbar/ViewItem.svelte
+++ b/src/ui/app/toolbar/ViewItem.svelte
@@ -92,15 +92,18 @@
           editing = false;
 
           // After executed, the label value read by on:blur
-          // is set to original value, to prevent rename
+          // is set to the original value, to prevent rename
           rollback();
         }
       }}
       on:blur={() => {
         if (!error) {
-          fallback = label;
+          // avoid unnessesary call
+          if (fallback != label) {
+            fallback = label;
 
-          dispatch("rename", label);
+            dispatch("rename", label);
+          }
         } else {
           rollback();
         }


### PR DESCRIPTION
Related to #572 (though closed as not planned). Manually tested and with the `data.json` file checked.

Original behavior:
- Accept rename by pressing `Enter`
- Rollback when clicking outside the `ViewItem` div element that have the view icon included, rather than the `TextInput` component

New design:
- Accept rename by pressing `Enter`
- Accept rename by clicking outside the `TextInput` component (through `on:blur()`)
- Rollback only when pressing `Esc`

It feels more natural to me, but if there's any concern, modifications to this PR are welcome.
Also, I left a comment besides the `rollback()` function when dealing with `Escape` case, explaining why the rollback action won't interferes with `on:blur()`. Should be removed if the comment is unneccessary.