### PR TITLE
Fix click to accept view rename

### DIFF
--- a/src/ui/app/toolbar/ViewItem.svelte
+++ b/src/ui/app/toolbar/ViewItem.svelte
@@ -100,10 +100,6 @@
         }
       }}
       on:blur={() => {
-        if (fallback == label) {
-          return;
-        }
-
         if (!error) {
           fallback = label;
 


### PR DESCRIPTION
In previous PR #639 , if we double click to enter the edit mode, then click outside to exit, the text will still in edit mode. Removing guard condition on `blur()` would apply a force rename though nothing was changed, therefore we can return to display mode safely.