### PR TITLE
Fix sorting empty values

### DIFF
--- a/src/ui/app/viewSort.test.ts
+++ b/src/ui/app/viewSort.test.ts
@@ -269,7 +269,7 @@ describe("applySort", () => {
     });
   });
 
-  it("sort by number (asc) and string (desc)", () => {
+  it("sort by number (asc) and string (asc)", () => {
     const sorted = applySort(frame, {
       criteria: [
         { field: "weight", order: "asc", enabled: true },
@@ -385,6 +385,421 @@ describe("natural sort", () => {
           id: "Section 11.md",
           values: {
             section: "11.References",
+          },
+        },
+      ],
+    });
+  });
+});
+
+describe("sort empty values to the end", () => {
+  const frame = {
+    fields: [],
+    records: [
+      {
+        id: "Bob.md",
+        values: {
+          author: null,
+          age: 2,
+          due: new Date(Date.UTC(2011, 1, 1)),
+        },
+      },
+      {
+        id: "Eve.md",
+        values: {
+          author: "",
+          age: 3,
+          due: new Date(Date.UTC(2031, 1, 1)),
+        },
+      },
+      {
+        id: "David.md",
+        values: {
+          author: undefined,
+          age: 4,
+          due: new Date(Date.UTC(2025, 1, 1)),
+        },
+      },
+      {
+        id: "Alice.md",
+        values: {
+          author: "Alice",
+          age: 1,
+          due: undefined,
+        },
+      },
+      {
+        id: "Charlie.md",
+        values: {
+          author: "Charlie",
+          age: null,
+          due: new Date(Date.UTC(2021, 1, 1)),
+        },
+      },
+    ],
+  };
+
+  it("sort by string asc", () => {
+    const sorted = applySort(frame, {
+      criteria: [{ field: "author", order: "asc", enabled: true }],
+    });
+
+    expect(sorted).toStrictEqual({
+      fields: [],
+      records: [
+        {
+          id: "Eve.md",
+          values: {
+            author: "",
+            age: 3,
+            due: new Date(Date.UTC(2031, 1, 1)),
+          },
+        },
+        {
+          id: "Alice.md",
+          values: {
+            author: "Alice",
+            age: 1,
+            due: undefined,
+          },
+        },
+        {
+          id: "Charlie.md",
+          values: {
+            author: "Charlie",
+            age: null,
+            due: new Date(Date.UTC(2021, 1, 1)),
+          },
+        },
+        {
+          id: "Bob.md",
+          values: {
+            author: null,
+            age: 2,
+            due: new Date(Date.UTC(2011, 1, 1)),
+          },
+        },
+        {
+          id: "David.md",
+          values: {
+            author: undefined,
+            age: 4,
+            due: new Date(Date.UTC(2025, 1, 1)),
+          },
+        },
+      ],
+    });
+  });
+
+  it("sort by string desc", () => {
+    const sorted = applySort(frame, {
+      criteria: [{ field: "author", order: "desc", enabled: true }],
+    });
+
+    expect(sorted).toStrictEqual({
+      fields: [],
+      records: [
+        {
+          id: "Charlie.md",
+          values: {
+            author: "Charlie",
+            age: null,
+            due: new Date(Date.UTC(2021, 1, 1)),
+          },
+        },
+        {
+          id: "Alice.md",
+          values: {
+            author: "Alice",
+            age: 1,
+            due: undefined,
+          },
+        },
+        {
+          id: "Eve.md",
+          values: {
+            author: "",
+            age: 3,
+            due: new Date(Date.UTC(2031, 1, 1)),
+          },
+        },
+        {
+          id: "Bob.md",
+          values: {
+            author: null,
+            age: 2,
+            due: new Date(Date.UTC(2011, 1, 1)),
+          },
+        },
+        {
+          id: "David.md",
+          values: {
+            author: undefined,
+            age: 4,
+            due: new Date(Date.UTC(2025, 1, 1)),
+          },
+        },
+      ],
+    });
+  });
+
+  it("sort by number asc", () => {
+    const sorted = applySort(frame, {
+      criteria: [{ field: "age", order: "asc", enabled: true }],
+    });
+
+    expect(sorted).toStrictEqual({
+      fields: [],
+      records: [
+        {
+          id: "Alice.md",
+          values: {
+            author: "Alice",
+            age: 1,
+            due: undefined,
+          },
+        },
+        {
+          id: "Bob.md",
+          values: {
+            author: null,
+            age: 2,
+            due: new Date(Date.UTC(2011, 1, 1)),
+          },
+        },
+        {
+          id: "Eve.md",
+          values: {
+            author: "",
+            age: 3,
+            due: new Date(Date.UTC(2031, 1, 1)),
+          },
+        },
+        {
+          id: "David.md",
+          values: {
+            author: undefined,
+            age: 4,
+            due: new Date(Date.UTC(2025, 1, 1)),
+          },
+        },
+        {
+          id: "Charlie.md",
+          values: {
+            author: "Charlie",
+            age: null,
+            due: new Date(Date.UTC(2021, 1, 1)),
+          },
+        },
+      ],
+    });
+  });
+
+  it("sort by number desc", () => {
+    const sorted = applySort(frame, {
+      criteria: [{ field: "age", order: "desc", enabled: true }],
+    });
+
+    expect(sorted).toStrictEqual({
+      fields: [],
+      records: [
+        {
+          id: "David.md",
+          values: {
+            author: undefined,
+            age: 4,
+            due: new Date(Date.UTC(2025, 1, 1)),
+          },
+        },
+        {
+          id: "Eve.md",
+          values: {
+            author: "",
+            age: 3,
+            due: new Date(Date.UTC(2031, 1, 1)),
+          },
+        },
+        {
+          id: "Bob.md",
+          values: {
+            author: null,
+            age: 2,
+            due: new Date(Date.UTC(2011, 1, 1)),
+          },
+        },
+        {
+          id: "Alice.md",
+          values: {
+            author: "Alice",
+            age: 1,
+            due: undefined,
+          },
+        },
+        {
+          id: "Charlie.md",
+          values: {
+            author: "Charlie",
+            age: null,
+            due: new Date(Date.UTC(2021, 1, 1)),
+          },
+        },
+      ],
+    });
+  });
+
+  it("sort by date asc", () => {
+    const sorted = applySort(frame, {
+      criteria: [{ field: "due", order: "asc", enabled: true }],
+    });
+
+    expect(sorted).toStrictEqual({
+      fields: [],
+      records: [
+        {
+          id: "Bob.md",
+          values: {
+            author: null,
+            age: 2,
+            due: new Date(Date.UTC(2011, 1, 1)),
+          },
+        },
+        {
+          id: "Charlie.md",
+          values: {
+            author: "Charlie",
+            age: null,
+            due: new Date(Date.UTC(2021, 1, 1)),
+          },
+        },
+        {
+          id: "David.md",
+          values: {
+            author: undefined,
+            age: 4,
+            due: new Date(Date.UTC(2025, 1, 1)),
+          },
+        },
+        {
+          id: "Eve.md",
+          values: {
+            author: "",
+            age: 3,
+            due: new Date(Date.UTC(2031, 1, 1)),
+          },
+        },
+        {
+          id: "Alice.md",
+          values: {
+            author: "Alice",
+            age: 1,
+            due: undefined,
+          },
+        },
+      ],
+    });
+  });
+
+  it("sort by date desc", () => {
+    const sorted = applySort(frame, {
+      criteria: [{ field: "due", order: "desc", enabled: true }],
+    });
+
+    expect(sorted).toStrictEqual({
+      fields: [],
+      records: [
+        {
+          id: "Eve.md",
+          values: {
+            author: "",
+            age: 3,
+            due: new Date(Date.UTC(2031, 1, 1)),
+          },
+        },
+        {
+          id: "David.md",
+          values: {
+            author: undefined,
+            age: 4,
+            due: new Date(Date.UTC(2025, 1, 1)),
+          },
+        },
+        {
+          id: "Charlie.md",
+          values: {
+            author: "Charlie",
+            age: null,
+            due: new Date(Date.UTC(2021, 1, 1)),
+          },
+        },
+        {
+          id: "Bob.md",
+          values: {
+            author: null,
+            age: 2,
+            due: new Date(Date.UTC(2011, 1, 1)),
+          },
+        },
+        {
+          id: "Alice.md",
+          values: {
+            author: "Alice",
+            age: 1,
+            due: undefined,
+          },
+        },
+      ],
+    });
+  });
+
+  it("sort by string (asc) and date (desc)", () => {
+    const sorted = applySort(frame, {
+      criteria: [
+        { field: "author", order: "asc", enabled: true },
+        { field: "due", order: "desc", enabled: true },
+      ],
+    });
+
+    expect(sorted).toStrictEqual({
+      fields: [],
+      records: [
+        {
+          id: "Eve.md",
+          values: {
+            author: "",
+            age: 3,
+            due: new Date(Date.UTC(2031, 1, 1)),
+          },
+        },
+        {
+          id: "Alice.md",
+          values: {
+            author: "Alice",
+            age: 1,
+            due: undefined,
+          },
+        },
+        {
+          id: "Charlie.md",
+          values: {
+            author: "Charlie",
+            age: null,
+            due: new Date(Date.UTC(2021, 1, 1)),
+          },
+        },
+        {
+          id: "David.md",
+          values: {
+            author: undefined,
+            age: 4,
+            due: new Date(Date.UTC(2025, 1, 1)),
+          },
+        },
+        {
+          id: "Bob.md",
+          values: {
+            author: null,
+            age: 2,
+            due: new Date(Date.UTC(2011, 1, 1)),
           },
         },
       ],

--- a/src/ui/app/viewSort.ts
+++ b/src/ui/app/viewSort.ts
@@ -67,7 +67,6 @@ function sortCriteria(
 
 function sortNumber(a: number, b: number, asc: boolean): number {
   if (a < b) {
-    console.log(a);
     return asc ? -1 : 1;
   }
   if (a > b) {

--- a/src/ui/app/viewSort.ts
+++ b/src/ui/app/viewSort.ts
@@ -45,8 +45,8 @@ function sortCriteria(
 
   const isAsc = criteria.order === "asc";
 
-  if (!isEmpty(aval) && isEmpty(bval)) return isAsc ? 1 : -1;
-  if (isEmpty(aval) && !isEmpty(bval)) return isAsc ? -1 : 1;
+  if (!isEmpty(aval) && isEmpty(bval)) return -1;
+  if (isEmpty(aval) && !isEmpty(bval)) return 1;
   if (isEmpty(aval) && isEmpty(bval)) return 0;
 
   if (isNumber(aval) && isNumber(bval)) {
@@ -67,6 +67,7 @@ function sortCriteria(
 
 function sortNumber(a: number, b: number, asc: boolean): number {
   if (a < b) {
+    console.log(a);
     return asc ? -1 : 1;
   }
   if (a > b) {


### PR DESCRIPTION
Fixes #590 & Fixes #682 

- Sept 22: Always put empty values (`null` or `undefined`) at the end of sorts.
- [x] Handle empty strings. (Treated as normal ones, empty strings comes first when asc, and last when desc)
- [x] Building tests.