### PR TITLE
Display read-only metadata

### DIFF
--- a/src/lib/stores/translations/en.json
+++ b/src/lib/stores/translations/en.json
@@ -183,6 +183,7 @@
                     "short-title": "Edit note",
                     "title": "Edit note",
                     "save": "Save",
+                    "confirm": "Confirm",
                     "no-editable-fields": {
                         "title": "No editable fields",
                         "message": "This note has no editable fields."

--- a/src/lib/stores/translations/zh-CN.json
+++ b/src/lib/stores/translations/zh-CN.json
@@ -183,6 +183,7 @@
                     "short-title": "编辑笔记",
                     "title": "编辑笔记元数据",
                     "save": "保存",
+                    "confirm": "确认",
                     "no-editable-fields": {
                         "title": "没有可编辑字段。",
                         "message": "这个笔记的元数据没有可编辑字段。"

--- a/src/ui/components/FieldControl/FieldControl.svelte
+++ b/src/ui/components/FieldControl/FieldControl.svelte
@@ -38,7 +38,7 @@
     on:check={({ detail }) => onChange(detail)}
   />
 {:else if field.repeated && isOptionalList(value)}
-  <TagList edit={true} values={value ?? []} {onChange} />
+  <TagList edit={!readonly} values={value ?? []} {onChange} />
 {:else if field.type === DataFieldType.String}
   {#if options.length > 0}
     <Autocomplete

--- a/src/ui/modals/components/EditNote.svelte
+++ b/src/ui/modals/components/EditNote.svelte
@@ -22,16 +22,33 @@
 </script>
 
 <ModalLayout title={$i18n.t("modals.note.edit.title")}>
+  {#if !editableFields.length}
+    <Callout
+      title={$i18n.t("modals.note.edit.no-editable-fields.title")}
+      icon="info"
+      variant="info"
+    >
+      {$i18n.t("modals.note.edit.no-editable-fields.message")}
+    </Callout>
+    <ModalContent>
+      {#each fields as field (field.name)}
+        <SettingItem name={field.name}>
+          <FieldControl
+            {field}
+            value={record.values[field.name]}
+            onChange={(value) => {
+              record = produce(record, (draft) => {
+                // @ts-ignore
+                draft.values[field.name] = value;
+              });
+            }}
+            readonly={true}
+          />
+        </SettingItem>
+      {/each}
+    </ModalContent>
+  {/if}
   <ModalContent>
-    {#if !editableFields.length}
-      <Callout
-        title={$i18n.t("modals.note.edit.no-editable-fields.title")}
-        icon="info"
-        variant="info"
-      >
-        {$i18n.t("modals.note.edit.no-editable-fields.message")}
-      </Callout>
-    {/if}
     {#each editableFields as field (field.name)}
       <SettingItem name={field.name}>
         <FieldControl
@@ -52,7 +69,10 @@
       variant="primary"
       on:click={() => {
         onSave(record);
-      }}>{$i18n.t("modals.note.edit.save")}</Button
+      }}
+      >{editableFields.length
+        ? $i18n.t("modals.note.edit.save")
+        : $i18n.t("modals.note.edit.confirm")}</Button
     >
   </ModalButtonGroup>
 </ModalLayout>


### PR DESCRIPTION
Fixes #562 

Input components and tag list components are also set to read-only. (Not disabled, there are some differences between the two UIs)