### PR TITLE
Filtering dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-projects",
-  "version": "1.16.3",
+  "version": "1.16.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-projects",
-      "version": "1.16.3",
+      "version": "1.16.5",
       "license": "MIT",
       "devDependencies": {
         "@interactjs/interact": "^1.10.17",

--- a/src/settings/base/settings.ts
+++ b/src/settings/base/settings.ts
@@ -87,6 +87,7 @@ export function isDateFilterOperator(
     "is-on-and-before",
     "is-on-and-after",
   ].includes(op);
+}
 
 export type ListFilterOperator = "has-any-of" | "has-all-of" | "has-none-of";
 
@@ -101,7 +102,7 @@ export type FilterOperator =
   | StringFilterOperator
   | NumberFilterOperator
   | BooleanFilterOperator
-  | DateFilterOperator;
+  | DateFilterOperator
   | ListFilterOperator;
 
 export type FilterOperatorType = "unary" | "binary";

--- a/src/settings/base/settings.ts
+++ b/src/settings/base/settings.ts
@@ -68,11 +68,33 @@ export function isBooleanFilterOperator(
   return ["is-checked", "is-not-checked"].includes(op);
 }
 
+export type DateFilterOperator =
+  | "is-on"
+  | "is-not-on"
+  | "is-before"
+  | "is-after"
+  | "is-on-and-before"
+  | "is-on-and-after";
+
+export function isDateFilterOperator(
+  op: FilterOperator
+): op is DateFilterOperator {
+  return [
+    "is-on",
+    "is-not-on",
+    "is-before",
+    "is-after",
+    "is-on-and-before",
+    "is-on-and-after",
+  ].includes(op);
+}
+
 export type FilterOperator =
   | BaseFilterOperator
   | StringFilterOperator
   | NumberFilterOperator
-  | BooleanFilterOperator;
+  | BooleanFilterOperator
+  | DateFilterOperator;
 
 export type FilterOperatorType = "unary" | "binary";
 
@@ -91,6 +113,12 @@ export const filterOperatorTypes: Record<FilterOperator, FilterOperatorType> = {
   gte: "binary",
   "is-checked": "unary",
   "is-not-checked": "unary",
+  "is-on": "binary",
+  "is-not-on": "binary",
+  "is-before": "binary",
+  "is-after": "binary",
+  "is-on-and-before": "binary",
+  "is-on-and-after": "binary",
 };
 
 export interface FilterCondition {

--- a/src/ui/app/filterFunctions.ts
+++ b/src/ui/app/filterFunctions.ts
@@ -84,29 +84,29 @@ export const baseFns: Record<
 
 export const stringFns: Record<
   StringFilterOperator,
-  (left: string, right?: string) => boolean
+  (left: Optional<string>, right?: string) => boolean
 > = {
-  is: (left, right) => left === right,
-  "is-not": (left, right) => left !== right,
-  contains: (left, right) => left.contains(right ?? ""),
-  "not-contains": (left, right) => !left.contains(right ?? ""),
+  is: (left, right) => (left ? left == right : false),
+  "is-not": (left, right) => (left ? left != right : true),
+  contains: (left, right) => (left ? left.contains(right ?? "") : false),
+  "not-contains": (left, right) => (left ? !left.contains(right ?? "") : true),
 };
 
 export const numberFns: Record<
   NumberFilterOperator,
-  (left: number, right?: number) => boolean
+  (left: Optional<number>, right?: number) => boolean
 > = {
   eq: (left, right) => left === right,
   neq: (left, right) => left !== right,
-  lt: (left, right) => (right ? left < right : false),
-  gt: (left, right) => (right ? left > right : false),
-  lte: (left, right) => (right ? left <= right : false),
-  gte: (left, right) => (right ? left >= right : false),
+  lt: (left, right) => (left && right ? left < right : false),
+  gt: (left, right) => (left && right ? left > right : false),
+  lte: (left, right) => (left && right ? left <= right : false),
+  gte: (left, right) => (left && right ? left >= right : false),
 };
 
 export const booleanFns: Record<
   BooleanFilterOperator,
-  (value: boolean) => boolean
+  (value: Optional<boolean>) => boolean
 > = {
   "is-checked": (value) => value === true,
   "is-not-checked": (value) => value === false,

--- a/src/ui/app/filterFunctions.ts
+++ b/src/ui/app/filterFunctions.ts
@@ -1,9 +1,12 @@
 import produce from "immer";
-import type {
-  DataFrame,
-  DataRecord,
-  DataValue,
-  Optional,
+import {
+  type DataFrame,
+  type DataRecord,
+  type DataValue,
+  type Optional,
+  isOptionalString,
+  isOptionalNumber,
+  isOptionalBoolean,
 } from "src/lib/dataframe/dataframe";
 import {
   isBooleanFilterOperator,
@@ -29,24 +32,15 @@ export function matchesCondition(
     return baseFns[operator](value);
   }
 
-  switch (typeof value) {
-    case "string":
-      if (isStringFilterOperator(operator)) {
-        return stringFns[operator](value, cond.value);
-      }
-      break;
-    case "number":
-      if (isNumberFilterOperator(operator)) {
-        return numberFns[operator](
-          value,
-          cond.value ? parseFloat(cond.value) : undefined
-        );
-      }
-      break;
-    case "boolean":
-      if (isBooleanFilterOperator(operator)) {
-        return booleanFns[operator](value);
-      }
+  if (isOptionalString(value) && isStringFilterOperator(operator)) {
+    return stringFns[operator](value, cond.value);
+  } else if (isOptionalNumber(value) && isNumberFilterOperator(operator)) {
+    return numberFns[operator](
+      value,
+      cond.value ? parseFloat(cond.value) : undefined
+    );
+  } else if (isOptionalBoolean(value) && isBooleanFilterOperator(operator)) {
+    return booleanFns[operator](value);
   }
 
   return false;

--- a/src/ui/app/filterFunctions.ts
+++ b/src/ui/app/filterFunctions.ts
@@ -9,8 +9,8 @@ import {
   isOptionalNumber,
   isOptionalBoolean,
   isOptionalDate,
+  isOptionalList,
 } from "src/lib/dataframe/dataframe";
-import { isOptionalList } from "src/lib/dataframe/dataframe";
 import {
   isBooleanFilterOperator,
   isNumberFilterOperator,
@@ -39,6 +39,14 @@ export function matchesCondition(
     return baseFns[operator](value);
   }
 
+  if (isOptionalList(value)) {
+    if (isListFilterOperator(operator)) {
+      return listFns[operator](
+        value ?? [],
+        cond.value ? JSON.parse(cond.value ?? "[]") : undefined
+      );
+    }
+  }
 
   if (isOptionalString(value) && isStringFilterOperator(operator)) {
     return stringFns[operator](value, cond.value);
@@ -54,34 +62,6 @@ export function matchesCondition(
       value,
       cond.value ? dayjs(cond.value ?? "").toDate() : undefined
     );
-
-  if (isOptionalList(value)) {
-    if (isListFilterOperator(operator)) {
-      return listFns[operator](
-        value ?? [],
-        cond.value ? JSON.parse(cond.value ?? "[]") : undefined
-      );
-    }
-  }
-
-  switch (typeof value) {
-    case "string":
-      if (isStringFilterOperator(operator)) {
-        return stringFns[operator](value, cond.value);
-      }
-      break;
-    case "number":
-      if (isNumberFilterOperator(operator)) {
-        return numberFns[operator](
-          value,
-          cond.value ? parseFloat(cond.value) : undefined
-        );
-      }
-      break;
-    case "boolean":
-      if (isBooleanFilterOperator(operator)) {
-        return booleanFns[operator](value);
-      }
   }
 
   return false;
@@ -164,6 +144,7 @@ export const dateFns: Record<
     left && right ? left.getTime() <= right.getTime() : false,
   "is-on-and-after": (left, right) =>
     left && right ? left.getTime() >= right.getTime() : false,
+};
 
 export const listFns: Record<
   ListFilterOperator,

--- a/src/ui/app/toolbar/viewOptions/color/ColorOptions.svelte
+++ b/src/ui/app/toolbar/viewOptions/color/ColorOptions.svelte
@@ -161,6 +161,7 @@
             <DateInput
               value={dayjs(rule.condition.value ?? "").toDate()}
               on:blur={handleValueChange(i)}
+            />
           {:else if isListFilterOperator(rule.condition.operator)}
             <TagsInput
               strict={true}

--- a/src/ui/app/toolbar/viewOptions/color/ColorOptions.svelte
+++ b/src/ui/app/toolbar/viewOptions/color/ColorOptions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import produce from "immer";
+  import dayjs from "dayjs";
   import { dndzone } from "svelte-dnd-action";
   import {
     Button,
@@ -10,6 +11,7 @@
     NumberInput,
     ColorInput,
     Checkbox,
+    DateInput,
   } from "obsidian-svelte";
   import HorizontalGroup from "src/ui/components/HorizontalGroup/HorizontalGroup.svelte";
   import type { DataField } from "src/lib/dataframe/dataframe";
@@ -17,6 +19,7 @@
     filterOperatorTypes,
     isNumberFilterOperator,
     isStringFilterOperator,
+    isDateFilterOperator,
     type ColorFilterDefinition,
     type FilterOperator,
   } from "src/settings/settings";
@@ -150,6 +153,11 @@
           {:else if isNumberFilterOperator(rule.condition.operator)}
             <NumberInput
               value={parseFloat(rule.condition.value ?? "")}
+              on:blur={handleValueChange(i)}
+            />
+          {:else if isDateFilterOperator(rule.condition.operator)}
+            <DateInput
+              value={dayjs(rule.condition.value ?? "").toDate()}
               on:blur={handleValueChange(i)}
             />
           {/if}

--- a/src/ui/app/toolbar/viewOptions/color/helpers.ts
+++ b/src/ui/app/toolbar/viewOptions/color/helpers.ts
@@ -185,6 +185,16 @@ export function getOperatorsByField(field: DataField): Array<{
         { label: "≤", value: "lte" },
         { label: "≥", value: "gte" },
       ];
+    case DataFieldType.Date:
+      return [
+        ...baseOperators,
+        { label: "is on", value: "is-on" },
+        { label: "is not on", value: "is-not-on" },
+        { label: "is before", value: "is-before" },
+        { label: "is after", value: "is-after" },
+        { label: "is on and before", value: "is-on-and-before" },
+        { label: "is on and after", value: "is-on-and-after" },
+      ];
   }
 
   return baseOperators;

--- a/src/ui/app/toolbar/viewOptions/filter/FilterOptions.svelte
+++ b/src/ui/app/toolbar/viewOptions/filter/FilterOptions.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import produce from "immer";
-  import dayjs from "dayjs";
   import {
     Button,
     IconButton,
@@ -9,7 +8,7 @@
     TextInput,
     NumberInput,
     Checkbox,
-    DateInput,
+    // DateInput, //use native date input temporarily,
   } from "obsidian-svelte";
   import HorizontalGroup from "src/ui/components/HorizontalGroup/HorizontalGroup.svelte";
   import type { DataField } from "src/lib/dataframe/dataframe";
@@ -114,9 +113,11 @@
             on:blur={handleValueChange(i)}
           />
         {:else if isDateFilterOperator(condition.operator)}
-          <DateInput
-            value={dayjs(condition.value ?? "").toDate()}
+          <input
+            type="date"
+            value={condition.value ?? ""}
             on:blur={handleValueChange(i)}
+            max="2999-12-31"
           />
         {/if}
       {/if}

--- a/src/ui/app/toolbar/viewOptions/filter/FilterOptions.svelte
+++ b/src/ui/app/toolbar/viewOptions/filter/FilterOptions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import produce from "immer";
+  import dayjs from "dayjs";
   import {
     Button,
     IconButton,
@@ -8,6 +9,7 @@
     TextInput,
     NumberInput,
     Checkbox,
+    DateInput,
   } from "obsidian-svelte";
   import HorizontalGroup from "src/ui/components/HorizontalGroup/HorizontalGroup.svelte";
   import type { DataField } from "src/lib/dataframe/dataframe";
@@ -15,6 +17,7 @@
     filterOperatorTypes,
     isNumberFilterOperator,
     isStringFilterOperator,
+    isDateFilterOperator,
     type FilterDefinition,
     type FilterOperator,
   } from "src/settings/settings";
@@ -108,6 +111,11 @@
         {:else if isNumberFilterOperator(condition.operator)}
           <NumberInput
             value={parseFloat(condition.value ?? "")}
+            on:blur={handleValueChange(i)}
+          />
+        {:else if isDateFilterOperator(condition.operator)}
+          <DateInput
+            value={dayjs(condition.value ?? "").toDate()}
             on:blur={handleValueChange(i)}
           />
         {/if}

--- a/src/ui/app/toolbar/viewOptions/filter/FilterOptions.svelte
+++ b/src/ui/app/toolbar/viewOptions/filter/FilterOptions.svelte
@@ -120,6 +120,7 @@
             value={condition.value ?? ""}
             on:blur={handleValueChange(i)}
             max="2999-12-31"
+          />
         {:else if isListFilterOperator(condition.operator)}
           <TagsInput
             strict={true}

--- a/src/ui/app/toolbar/viewOptions/filter/helpers.ts
+++ b/src/ui/app/toolbar/viewOptions/filter/helpers.ts
@@ -104,6 +104,16 @@ export function getOperatorsByField(field: DataField): Array<{
         { label: "≤", value: "lte" },
         { label: "≥", value: "gte" },
       ];
+    case DataFieldType.Date:
+      return [
+        ...baseOperators,
+        { label: "is on", value: "is-on" },
+        { label: "is not on", value: "is-not-on" },
+        { label: "is before", value: "is-before" },
+        { label: "is after", value: "is-after" },
+        { label: "is on and before", value: "is-on-and-before" },
+        { label: "is on and after", value: "is-on-and-after" },
+      ];
   }
 
   return baseOperators;


### PR DESCRIPTION
Fixes #363 , thanks @sorinbiriescu for the early works!

- Sept 23: Add date filters
- Oct 27: Preview version
- [x] Awaiting obsidian-svelte add onblur to `DateInput`, and update the dependency
- [x] Restrict keyboard 6-digits year input. (Thru max prop on `input` tag, [stack overflow](https://stackoverflow.com/questions/64660946/html-is-there-a-way-to-limit-the-year-to-4-digits-in-date-input))

Max prop on date input:
<img width="960" alt="image" src="https://github.com/marcusolsson/obsidian-projects/assets/73122375/788fa207-1d8e-4b9e-b167-cf2bd71caad2">

