### PR TITLE
Archive and restore projects

### DIFF
--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -97,17 +97,17 @@ function createSettings() {
         })
       );
     },
-    restoreArchive(projectId: ProjectId) {
+    restoreArchive(archiveId: ProjectId) {
       update((state) =>
         produce(state, (draft) => {
-          const archive = draft.archives.find((p) => p.id === projectId);
+          const archive = draft.archives.find((a) => a.id === archiveId);
           if (archive) {
             draft.projects.push({
               ...archive,
               name: nextUniqueProjectName(draft.projects, archive.name),
             });
           }
-          draft.archives = draft.archives.filter((w) => w.id !== projectId);
+          draft.archives = draft.archives.filter((w) => w.id !== archiveId);
         })
       );
     },

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -101,13 +101,17 @@ function createSettings() {
       update((state) =>
         produce(state, (draft) => {
           const archive = draft.archives.find((p) => p.id === projectId);
-          if (archive) draft.projects.push(archive);
+          if (archive) {
+            draft.projects.push({
+              ...archive,
+              name: nextUniqueProjectName(draft.projects, archive.name),
+            });
+          }
           draft.archives = draft.archives.filter((w) => w.id !== projectId);
         })
       );
     },
     deleteArchive(projectId: ProjectId) {
-      // remove commands
       update((state) =>
         produce(state, (draft) => {
           draft.archives = draft.archives.filter((w) => w.id !== projectId);

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -97,11 +97,11 @@ function createSettings() {
         })
       );
     },
-    restoreProject(projectId: ProjectId) {
+    restoreArchive(projectId: ProjectId) {
       update((state) =>
         produce(state, (draft) => {
-          const project = draft.archives.find((p) => p.id === projectId);
-          if (project) draft.projects.push(project);
+          const archive = draft.archives.find((p) => p.id === projectId);
+          if (archive) draft.projects.push(archive);
           draft.archives = draft.archives.filter((w) => w.id !== projectId);
         })
       );

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -88,6 +88,32 @@ function createSettings() {
       );
       return newId;
     },
+    archiveProject(projectId: ProjectId) {
+      update((state) =>
+        produce(state, (draft) => {
+          const project = draft.projects.find((p) => p.id === projectId);
+          if (project) draft.archives.push(project);
+          draft.projects = draft.projects.filter((w) => w.id !== projectId);
+        })
+      );
+    },
+    restoreProject(projectId: ProjectId) {
+      update((state) =>
+        produce(state, (draft) => {
+          const project = draft.archives.find((p) => p.id === projectId);
+          if (project) draft.projects.push(project);
+          draft.archives = draft.archives.filter((w) => w.id !== projectId);
+        })
+      );
+    },
+    deleteArchive(projectId: ProjectId) {
+      // remove commands
+      update((state) =>
+        produce(state, (draft) => {
+          draft.archives = draft.archives.filter((w) => w.id !== projectId);
+        })
+      );
+    },
     deleteProject(projectId: ProjectId) {
       update((state) =>
         produce(state, (draft) => {

--- a/src/lib/stores/translations/en.json
+++ b/src/lib/stores/translations/en.json
@@ -183,6 +183,7 @@
                     "short-title": "Edit note",
                     "title": "Edit note",
                     "save": "Save",
+                    "confirm": "Confirm",
                     "no-editable-fields": {
                         "title": "No editable fields",
                         "message": "This note has no editable fields."

--- a/src/lib/stores/translations/en.json
+++ b/src/lib/stores/translations/en.json
@@ -55,10 +55,16 @@
                     "title": "Duplicate project",
                     "suffix": "Copy"
                 },
+                "archive": {
+                    "short-title": "Archive project",
+                    "title": "Archive project",
+                    "message": "Are you sure you want to archive \"{{project}}\"? You can restore the project later in Projects plugin's setting tab.",
+                    "cta": "Archive"
+                },
                 "delete": {
                     "short-title": "Delete project",
                     "title": "Delete project",
-                    "message": "Are you sure you want to delete \"{{project}}\"?",
+                    "message": "Are you sure you want to delete \"{{project}}\"? This operation cannot be undone.",
                     "cta": "Delete"
                 },
                 "name": {

--- a/src/lib/stores/translations/en.json
+++ b/src/lib/stores/translations/en.json
@@ -58,13 +58,13 @@
                 "archive": {
                     "short-title": "Archive project",
                     "title": "Archive project",
-                    "message": "Are you sure you want to archive \"{{project}}\"? You can restore the project later in Projects plugin's setting tab.",
+                    "message": "Are you sure you want to archive \"{{project}}\"? You can restore it later in Projects plugin's setting tab.",
                     "cta": "Archive"
                 },
                 "delete": {
                     "short-title": "Delete project",
                     "title": "Delete project",
-                    "message": "Are you sure you want to delete \"{{project}}\"? This operation cannot be undone.",
+                    "message": "Are you sure you want to delete \"{{project}}\"? This cannot be undone.",
                     "cta": "Delete"
                 },
                 "name": {
@@ -129,6 +129,14 @@
                     "name": "Default name for new notes",
                     "description": "Supports {{date:YYYY-MM-DD}} and {{time:HHmm}} templates variables.",
                     "invalid": "Contains illegal characters."
+                }
+            },
+            "archive": {
+                "delete": {
+                    "short-title": "Delete archive",
+                    "title": "Delete archive",
+                    "message": "Are you sure you want to delete \"{{archive}}\"? This cannot be undone.",
+                    "cta": "Delete"
                 }
             },
             "view": {

--- a/src/lib/stores/translations/zh-CN.json
+++ b/src/lib/stores/translations/zh-CN.json
@@ -183,6 +183,7 @@
                     "short-title": "编辑笔记",
                     "title": "编辑笔记元数据",
                     "save": "保存",
+                    "confirm": "确认",
                     "no-editable-fields": {
                         "title": "没有可编辑字段。",
                         "message": "这个笔记的元数据没有可编辑字段。"

--- a/src/lib/stores/translations/zh-CN.json
+++ b/src/lib/stores/translations/zh-CN.json
@@ -55,10 +55,16 @@
                     "title": "复制项目",
                     "suffix": "副本"
                 },
+                "archive": {
+                    "short-title": "存档项目",
+                    "title": "存档项目",
+                    "message": "确定要存档项目 \"{{project}}\" 吗？存档后，您可以在 Projects 插件设置中恢复该项目。",
+                    "cta": "存档"
+                },
                 "delete": {
                     "short-title": "删除项目",
                     "title": "删除项目",
-                    "message": "确定要删除项目 \"{{project}}\" 吗？",
+                    "message": "确定要删除项目 \"{{project}}\" 吗？此操作不可撤销。",
                     "cta": "删除"
                 },
                 "name": {

--- a/src/lib/stores/translations/zh-CN.json
+++ b/src/lib/stores/translations/zh-CN.json
@@ -58,7 +58,7 @@
                 "archive": {
                     "short-title": "存档项目",
                     "title": "存档项目",
-                    "message": "确定要存档项目 \"{{project}}\" 吗？存档后，您可以在 Projects 插件设置中恢复该项目。",
+                    "message": "确定要存档项目 \"{{project}}\" 吗？若需要，您可以在 Projects 插件设置中恢复该项目。",
                     "cta": "存档"
                 },
                 "delete": {
@@ -129,6 +129,14 @@
                     "name": "默认笔记名称",
                     "description": "支持 {{date:YYYY-MM-DD}} 和 {{time:HHmm}} 格式的日期、时间模板变量。",
                     "invalid": "笔记名包含非法字符。"
+                }
+            },
+            "archive": {
+                "delete": {
+                    "short-title": "删除存档",
+                    "title": "删除存档",
+                    "message": "确定要删除存档 \"{{archive}}\" 吗？此操作不可撤销。",
+                    "cta": "删除"
                 }
             },
             "view": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ import { CreateProjectModal } from "src/ui/modals/createProjectModal";
 import { get, type Unsubscriber } from "svelte/store";
 import { registerFileEvents } from "./events";
 import { ObsidianFileSystemWatcher } from "./lib/filesystem/obsidian/filesystem";
-import { ProjectsSettingTab } from "./settings";
+import { ProjectsSettingTab } from "./ui/settings/settings";
 import {
   migrateSettings,
   type ProjectDefinition,

--- a/src/settings/settings.test.ts
+++ b/src/settings/settings.test.ts
@@ -222,6 +222,7 @@ const v2demo: v2.ProjectsPluginSettings<
       id: "861e5eaf-162e-4c4b-be1e-7556e2a8c889",
     },
   ],
+  archives: [],
   preferences: {
     projectSizeLimit: 1000,
     frontmatter: {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -47,6 +47,7 @@ export function migrate(
   return {
     version: 2,
     projects: v1settings.projects.map(migrateProject),
+    archives: [],
     preferences: v1settings.preferences,
   };
 }

--- a/src/settings/v2/settings.test.ts
+++ b/src/settings/v2/settings.test.ts
@@ -8,6 +8,7 @@ describe("resolve v2", () => {
     expect(got).toStrictEqual({
       version: 2,
       projects: [],
+      archives: [],
       preferences: {
         frontmatter: {
           quoteStrings: "PLAIN",
@@ -44,6 +45,7 @@ describe("resolve v2", () => {
           views: [],
         },
       ],
+      archives: [],
       preferences: {
         frontmatter: {
           quoteStrings: "PLAIN",

--- a/src/settings/v2/settings.ts
+++ b/src/settings/v2/settings.ts
@@ -53,6 +53,7 @@ export type UnsavedProjectDefinition = Omit<
 export type ProjectsPluginSettings<T> = {
   readonly version: 2;
   readonly projects: T[];
+  readonly archives: T[];
   readonly preferences: ProjectsPluginPreferences;
 };
 
@@ -78,6 +79,7 @@ export const DEFAULT_SETTINGS: ProjectsPluginSettings<
 > = {
   version: 2,
   projects: [],
+  archives: [],
   preferences: {
     projectSizeLimit: 1000,
     frontmatter: {
@@ -100,6 +102,7 @@ export function resolve(
   return {
     version: 2,
     projects: unresolved.projects?.map(resolveProject) ?? [],
+    archives: unresolved.archives?.map(resolveProject) ?? [],
     preferences: resolvePreferences(unresolved.preferences ?? {}),
   };
 }

--- a/src/ui/app/toolbar/ProjectSelect.svelte
+++ b/src/ui/app/toolbar/ProjectSelect.svelte
@@ -75,6 +75,27 @@
 
       menu.addItem((item) => {
         item
+          .setTitle($i18n.t("modals.project.archive.short-title"))
+          .setIcon("archive")
+          .onClick(() => {
+            new ConfirmDialogModal(
+              $app,
+              $i18n.t("modals.project.archive.title"),
+              $i18n.t("modals.project.archive.message", {
+                project: project?.name ?? "",
+              }),
+              $i18n.t("modals.project.archive.cta"),
+              () => {
+                if (projectId) {
+                  settings.archiveProject(projectId);
+                }
+              }
+            ).open();
+          });
+      });
+
+      menu.addItem((item) => {
+        item
           .setTitle($i18n.t("modals.project.delete.short-title"))
           .setIcon("trash")
           .onClick(() => {

--- a/src/ui/components/FieldControl/FieldControl.svelte
+++ b/src/ui/components/FieldControl/FieldControl.svelte
@@ -38,7 +38,7 @@
     on:check={({ detail }) => onChange(detail)}
   />
 {:else if field.repeated && isOptionalList(value)}
-  <TagList edit={true} values={value ?? []} {onChange} />
+  <TagList edit={!readonly} values={value ?? []} {onChange} />
 {:else if field.type === DataFieldType.String}
   {#if options.length > 0}
     <Autocomplete

--- a/src/ui/modals/components/CreateProject.svelte
+++ b/src/ui/modals/components/CreateProject.svelte
@@ -12,6 +12,7 @@
     Switch,
     TextArea,
     TextInput,
+    Typography,
   } from "obsidian-svelte";
 
   import { FileListInput } from "src/ui/components/FileListInput";
@@ -256,7 +257,9 @@
           icon="zap"
           variant="danger"
         >
-          {$i18n.t("modals.project.dataview.error.message")}
+          <Typography variant="body">
+            {$i18n.t("modals.project.dataview.error.message")}
+          </Typography>
         </Callout>
       {/if}
     {/if}

--- a/src/ui/modals/components/EditNote.svelte
+++ b/src/ui/modals/components/EditNote.svelte
@@ -7,6 +7,7 @@
     ModalContent,
     ModalLayout,
     SettingItem,
+    Typography,
   } from "obsidian-svelte";
 
   import { FieldControl } from "src/ui/components/FieldControl";
@@ -28,7 +29,9 @@
       icon="info"
       variant="info"
     >
-      {$i18n.t("modals.note.edit.no-editable-fields.message")}
+      <Typography variant="body">
+        {$i18n.t("modals.note.edit.no-editable-fields.message")}
+      </Typography>
     </Callout>
     <ModalContent>
       {#each fields as field (field.name)}

--- a/src/ui/modals/components/EditNote.svelte
+++ b/src/ui/modals/components/EditNote.svelte
@@ -22,16 +22,33 @@
 </script>
 
 <ModalLayout title={$i18n.t("modals.note.edit.title")}>
+  {#if !editableFields.length}
+    <Callout
+      title={$i18n.t("modals.note.edit.no-editable-fields.title")}
+      icon="info"
+      variant="info"
+    >
+      {$i18n.t("modals.note.edit.no-editable-fields.message")}
+    </Callout>
+    <ModalContent>
+      {#each fields as field (field.name)}
+        <SettingItem name={field.name}>
+          <FieldControl
+            {field}
+            value={record.values[field.name]}
+            onChange={(value) => {
+              record = produce(record, (draft) => {
+                // @ts-ignore
+                draft.values[field.name] = value;
+              });
+            }}
+            readonly={true}
+          />
+        </SettingItem>
+      {/each}
+    </ModalContent>
+  {/if}
   <ModalContent>
-    {#if !editableFields.length}
-      <Callout
-        title={$i18n.t("modals.note.edit.no-editable-fields.title")}
-        icon="info"
-        variant="info"
-      >
-        {$i18n.t("modals.note.edit.no-editable-fields.message")}
-      </Callout>
-    {/if}
     {#each editableFields as field (field.name)}
       <SettingItem name={field.name}>
         <FieldControl
@@ -52,7 +69,10 @@
       variant="primary"
       on:click={() => {
         onSave(record);
-      }}>{$i18n.t("modals.note.edit.save")}</Button
+      }}
+      >{editableFields.length
+        ? $i18n.t("modals.note.edit.save")
+        : $i18n.t("modals.note.edit.confirm")}</Button
     >
   </ModalButtonGroup>
 </ModalLayout>

--- a/src/ui/settings/Archives.svelte
+++ b/src/ui/settings/Archives.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { IconButton, SettingItem } from "obsidian-svelte";
+
+  import { i18n } from "src/lib/stores/i18n";
+  import { Accordion, AccordionItem } from "src/ui/components/Accordion";
+  import type { ProjectDefinition, ProjectId } from "src/settings/settings";
+
+  export let archives: ProjectDefinition[];
+
+</script>
+
+<span>
+  <Accordion>
+    <AccordionItem>
+      <div slot="header" class="setting-item-info" style:margin-top="8px">
+        <div class="setting-item-name">
+          {$i18n.t("modals.project.more-settings.name")}
+        </div>
+      </div>
+      {#each archives as project}
+        <SettingItem name={project.name} description={""}>
+          <IconButton icon="trash" />
+        </SettingItem>
+      {/each}
+    </AccordionItem>
+  </Accordion>
+</span>
+
+<style>
+</style>

--- a/src/ui/settings/Archives.svelte
+++ b/src/ui/settings/Archives.svelte
@@ -1,30 +1,71 @@
 <script lang="ts">
-  import { IconButton, SettingItem } from "obsidian-svelte";
-
+  import {
+    Callout,
+    IconButton,
+    SettingItem,
+    Typography,
+  } from "obsidian-svelte";
   import { i18n } from "src/lib/stores/i18n";
-  import { Accordion, AccordionItem } from "src/ui/components/Accordion";
-  import type { ProjectDefinition, ProjectId } from "src/settings/settings";
+  import { app } from "src/lib/stores/obsidian";
+  import { settings } from "src/lib/stores/settings";
+  import { ConfirmDialogModal } from "src/ui/modals/confirmDialog";
+  import type { ProjectDefinition } from "src/settings/settings";
 
-  export let archives: ProjectDefinition[];
+  $: ({ archives } = $settings);
 
+  const dataSourceDetail = (archive: ProjectDefinition) => {
+    switch (archive.dataSource.kind) {
+      case "folder":
+        return `${$i18n.t("datasources.folder")} path: "${
+          archive.dataSource.config.path
+        }"`;
+      case "tag":
+        return `${$i18n.t("datasources.tag")}: ${
+          archive.dataSource.config.tag
+        }`;
+      case "dataview":
+        return `${$i18n.t("datasources.dataview")} query: ${
+          archive.dataSource.config.query
+        }`;
+    }
+  };
+
+  const getDescription = (archive: ProjectDefinition) => {
+    const viewCount = `${archive.views.length} views.`;
+    const detail = dataSourceDetail(archive);
+    return [viewCount, detail].join(" ");
+  };
 </script>
 
-<span>
-  <Accordion>
-    <AccordionItem>
-      <div slot="header" class="setting-item-info" style:margin-top="8px">
-        <div class="setting-item-name">
-          {$i18n.t("modals.project.more-settings.name")}
-        </div>
-      </div>
-      {#each archives as project}
-        <SettingItem name={project.name} description={""}>
-          <IconButton icon="trash" />
-        </SettingItem>
-      {/each}
-    </AccordionItem>
-  </Accordion>
-</span>
-
-<style>
-</style>
+{#if !archives.length}
+  <Callout title={"Info"} icon="info" variant="info">
+    <Typography variant="body">No archived project.</Typography>
+  </Callout>
+{:else}
+  {#each archives as archive}
+    <SettingItem name={`${archive.name}`} description={getDescription(archive)}>
+      <IconButton
+        icon="archive-restore"
+        tooltip="Restore this archive"
+        onClick={() => settings.restoreArchive(archive.id)}
+      />
+      <IconButton
+        icon="trash-2"
+        tooltip="Delete this archive"
+        onClick={() => {
+          new ConfirmDialogModal(
+            $app,
+            $i18n.t("modals.archive.delete.title"),
+            $i18n.t("modals.archive.delete.message", {
+              archive: archive?.name ?? "",
+            }),
+            $i18n.t("modals.project.delete.cta"),
+            () => {
+              settings.deleteArchive(archive.id);
+            }
+          ).open();
+        }}
+      />
+    </SettingItem>
+  {/each}
+{/if}

--- a/src/ui/settings/Archives.svelte
+++ b/src/ui/settings/Archives.svelte
@@ -44,11 +44,7 @@
   </Callout>
 {:else}
   {#each archives as archive}
-    <SettingItem
-      name={`${archive.name}`}
-      description={getDescription(archive)}
-      heading={true}
-    >
+    <SettingItem name={`${archive.name}`} description={getDescription(archive)}>
       <IconButton
         icon="archive-restore"
         tooltip="Restore this archive"

--- a/src/ui/settings/Archives.svelte
+++ b/src/ui/settings/Archives.svelte
@@ -7,11 +7,8 @@
   } from "obsidian-svelte";
   import { i18n } from "src/lib/stores/i18n";
   import { app } from "src/lib/stores/obsidian";
-  import { settings } from "src/lib/stores/settings";
   import { ConfirmDialogModal } from "src/ui/modals/confirmDialog";
-  import type { ProjectDefinition } from "src/settings/settings";
-
-  $: ({ archives } = $settings);
+  import type { ProjectDefinition, ProjectId } from "src/settings/settings";
 
   const dataSourceDetail = (archive: ProjectDefinition) => {
     switch (archive.dataSource.kind) {
@@ -35,6 +32,10 @@
     const detail = dataSourceDetail(archive);
     return [viewCount, detail].join(" ");
   };
+
+  export let archives: ProjectDefinition[];
+  export let onRestore: (archiveId: ProjectId) => void;
+  export let onDelete: (archiveId: ProjectId) => void;
 </script>
 
 {#if !archives.length}
@@ -43,11 +44,15 @@
   </Callout>
 {:else}
   {#each archives as archive}
-    <SettingItem name={`${archive.name}`} description={getDescription(archive)}>
+    <SettingItem
+      name={`${archive.name}`}
+      description={getDescription(archive)}
+      heading={true}
+    >
       <IconButton
         icon="archive-restore"
         tooltip="Restore this archive"
-        onClick={() => settings.restoreArchive(archive.id)}
+        onClick={() => onRestore(archive.id)}
       />
       <IconButton
         icon="trash-2"
@@ -61,7 +66,7 @@
             }),
             $i18n.t("modals.project.delete.cta"),
             () => {
-              settings.deleteArchive(archive.id);
+              onDelete(archive.id);
             }
           ).open();
         }}

--- a/src/ui/settings/Archives.svelte
+++ b/src/ui/settings/Archives.svelte
@@ -9,17 +9,18 @@
   import { app } from "src/lib/stores/obsidian";
   import { ConfirmDialogModal } from "src/ui/modals/confirmDialog";
   import type { ProjectDefinition, ProjectId } from "src/settings/settings";
+  import { normalizePath } from "obsidian";
 
   const dataSourceDetail = (archive: ProjectDefinition) => {
     switch (archive.dataSource.kind) {
       case "folder":
-        return `${$i18n.t("datasources.folder")} path: "${
+        return `${$i18n.t("datasources.folder")}: "${normalizePath(
           archive.dataSource.config.path
-        }"`;
+        )}", subfolder: ${archive.dataSource.config.recursive}`; // normalize!
       case "tag":
         return `${$i18n.t("datasources.tag")}: ${
           archive.dataSource.config.tag
-        }`;
+        }, hierarchy: ${archive.dataSource.config.hierarchy}`;
       case "dataview":
         return `${$i18n.t("datasources.dataview")} query: ${
           archive.dataSource.config.query
@@ -28,9 +29,9 @@
   };
 
   const getDescription = (archive: ProjectDefinition) => {
-    const viewCount = `${archive.views.length} views.`;
-    const detail = dataSourceDetail(archive);
-    return [viewCount, detail].join(" ");
+    return [`${archive.views.length} view(s).`, dataSourceDetail(archive)].join(
+      " "
+    );
   };
 
   export let archives: ProjectDefinition[];

--- a/src/ui/settings/Archives.svelte
+++ b/src/ui/settings/Archives.svelte
@@ -16,7 +16,7 @@
       case "folder":
         return `${$i18n.t("datasources.folder")}: "${normalizePath(
           archive.dataSource.config.path
-        )}", subfolder: ${archive.dataSource.config.recursive}`; // normalize!
+        )}", subfolder: ${archive.dataSource.config.recursive}`;
       case "tag":
         return `${$i18n.t("datasources.tag")}: ${
           archive.dataSource.config.tag

--- a/src/ui/settings/Projects.svelte
+++ b/src/ui/settings/Projects.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import produce from "immer";
+  import { Callout, SettingItem, Typography, Switch } from "obsidian-svelte";
+
+  import { settings } from "src/lib/stores/settings";
+  import type { ProjectsPluginPreferences } from "../../settings/settings";
+
+  const save = (prefs: ProjectsPluginPreferences) => {
+    preferences = prefs;
+    settings.updatePreferences(prefs);
+  };
+
+  $: ({ projects } = $settings);
+  $: ({ preferences } = $settings);
+</script>
+
+{#if !projects.length}
+  <Callout title={"Info"} icon="info" variant="info">
+    <Typography variant="body">No project yet.</Typography>
+  </Callout>
+{:else}
+  {#each projects as project}
+    <SettingItem name={`${project.name}`} description={"Project"}>
+      <Switch
+        checked={!!preferences.commands.find(
+          (command) => command.project == project.id && !command.view
+        )}
+        on:check={({ detail }) => {
+          save(
+            produce(preferences, (draft) => {
+              if (detail) {
+                draft.commands.push({
+                  project: project.id,
+                });
+              } else {
+                draft.commands = draft.commands.filter(
+                  (command) =>
+                    !(command.project === project.id && !command.view)
+                );
+              }
+            })
+          );
+        }}
+      />
+    </SettingItem>
+    {#each project.views as view}
+      <SettingItem name={`${project.name}: ${view.name}`} description="View">
+        <Switch
+          checked={!!preferences.commands.find(
+            (command) =>
+              command.project == project.id && command.view === view.id
+          )}
+          on:check={({ detail }) => {
+            save(
+              produce(preferences, (draft) => {
+                if (detail) {
+                  draft.commands.push({
+                    project: project.id,
+                    view: view.id,
+                  });
+                } else {
+                  draft.commands = draft.commands.filter(
+                    (command) =>
+                      !(
+                        command.project === project.id &&
+                        command.view === view.id
+                      )
+                  );
+                }
+              })
+            );
+          }}
+        />
+      </SettingItem>
+    {/each}
+  {/each}
+{/if}

--- a/src/ui/settings/Projects.svelte
+++ b/src/ui/settings/Projects.svelte
@@ -1,17 +1,14 @@
 <script lang="ts">
   import produce from "immer";
   import { Callout, SettingItem, Typography, Switch } from "obsidian-svelte";
+  import type {
+    ProjectDefinition,
+    ProjectsPluginPreferences,
+  } from "src/settings/settings";
 
-  import { settings } from "src/lib/stores/settings";
-  import type { ProjectsPluginPreferences } from "../../settings/settings";
-
-  const save = (prefs: ProjectsPluginPreferences) => {
-    preferences = prefs;
-    settings.updatePreferences(prefs);
-  };
-
-  $: ({ projects } = $settings);
-  $: ({ preferences } = $settings);
+  export let preferences: ProjectsPluginPreferences;
+  export let projects: ProjectDefinition[];
+  export let save: (prefs: ProjectsPluginPreferences) => void;
 </script>
 
 {#if !projects.length}

--- a/src/ui/settings/settings.ts
+++ b/src/ui/settings/settings.ts
@@ -1,5 +1,5 @@
-import produce from "immer";
 import { App, Platform, PluginSettingTab, Setting } from "obsidian";
+import Projects from "src/ui/settings/Projects.svelte";
 import Archives from "src/ui/settings/Archives.svelte";
 import { settings } from "src/lib/stores/settings";
 import { get } from "svelte/store";
@@ -19,9 +19,7 @@ export class ProjectsSettingTab extends PluginSettingTab {
 
   // display runs when the user opens the settings tab.
   display(): void {
-    const { projects } = get(settings);
-    const { archives } = get(settings);
-    let { preferences } = get(settings); //TODO: remove commands upon delete! and archive?
+    let { preferences } = get(settings);
 
     const save = (prefs: ProjectsPluginPreferences) => {
       preferences = prefs;
@@ -93,69 +91,8 @@ export class ProjectsSettingTab extends PluginSettingTab {
       .setDesc("Add commands for your favorite projects and views.")
       .setHeading();
 
-    projects.forEach((project) => {
-      new Setting(containerEl)
-        .setName(project.name)
-        .setDesc("Project")
-        .addToggle((toggle) =>
-          toggle
-            .setValue(
-              !!preferences.commands.find(
-                (command) => command.project == project.id && !command.view
-              )
-            )
-            .onChange((value) => {
-              save(
-                produce(preferences, (draft) => {
-                  if (value) {
-                    draft.commands.push({
-                      project: project.id,
-                    });
-                  } else {
-                    draft.commands = draft.commands.filter(
-                      (command) =>
-                        !(command.project === project.id && !command.view)
-                    );
-                  }
-                })
-              );
-            })
-        );
-
-      project.views.forEach((view) => {
-        new Setting(containerEl)
-          .setName(`${project.name}: ${view.name}`)
-          .setDesc("View")
-          .addToggle((toggle) =>
-            toggle
-              .setValue(
-                !!preferences.commands.find(
-                  (command) =>
-                    command.project == project.id && command.view === view.id
-                )
-              )
-              .onChange((value) => {
-                save(
-                  produce(preferences, (draft) => {
-                    if (value) {
-                      draft.commands.push({
-                        project: project.id,
-                        view: view.id,
-                      });
-                    } else {
-                      draft.commands = draft.commands.filter(
-                        (command) =>
-                          !(
-                            command.project === project.id &&
-                            command.view === view.id
-                          )
-                      );
-                    }
-                  })
-                );
-              })
-          );
-      });
+    new Projects({
+      target: containerEl,
     });
 
     new Setting(containerEl)
@@ -165,54 +102,6 @@ export class ProjectsSettingTab extends PluginSettingTab {
 
     new Archives({
       target: containerEl,
-      props: {
-        archives: archives,
-      },
-    });
-
-    archives.forEach((archive) => {
-      new Setting(containerEl)
-        .setName(archive.name)
-        .setDesc("Archived project")
-        .addExtraButton((button) =>
-          button
-            .setIcon("view")
-            .setTooltip("Preview the archived project temproraly.")
-        ) // Preview the project, readonly
-        .addExtraButton((button) =>
-          button
-            .setIcon("archive-restore")
-            .setTooltip("Restore archive xxx(hint the name)")
-        ) // restore archive, update the list.
-        .addExtraButton((button) =>
-          button
-            .setIcon("trash-2")
-            .setTooltip("Delete this archive, add name hint")
-        ) // delete archive, abandon it.
-        .addToggle((toggle) =>
-          toggle
-            .setValue(
-              !!preferences.commands.find(
-                (command) => command.project == archive.id && !command.view
-              )
-            )
-            .onChange((value) => {
-              save(
-                produce(preferences, (draft) => {
-                  if (value) {
-                    draft.commands.push({
-                      project: archive.id,
-                    });
-                  } else {
-                    draft.commands = draft.commands.filter(
-                      (command) =>
-                        !(command.project === archive.id && !command.view)
-                    );
-                  }
-                })
-              );
-            })
-        );
     });
   }
 }

--- a/src/ui/settings/settings.ts
+++ b/src/ui/settings/settings.ts
@@ -3,11 +3,12 @@ import Projects from "src/ui/settings/Projects.svelte";
 import Archives from "src/ui/settings/Archives.svelte";
 import { settings } from "src/lib/stores/settings";
 import { get } from "svelte/store";
-import type ProjectsPlugin from "../../main";
+import type ProjectsPlugin from "src/main";
 import type {
   LinkBehavior,
+  ProjectId,
   ProjectsPluginPreferences,
-} from "../../settings/settings";
+} from "src/settings/settings";
 
 /**
  * ProjectsSettingTab builds the plugin settings tab.
@@ -91,17 +92,34 @@ export class ProjectsSettingTab extends PluginSettingTab {
       .setDesc("Add commands for your favorite projects and views.")
       .setHeading();
 
-    new Projects({
+    const projectsManager = new Projects({
       target: containerEl,
+      props: {
+        save,
+        preferences,
+        projects: get(settings).projects,
+      },
     });
 
     new Setting(containerEl)
       .setName("Archives")
-      .setDesc("View, preview, restore or delete your archived projects.")
+      .setDesc("Restore or delete your archived projects.")
       .setHeading();
 
-    new Archives({
+    const archivesManager = new Archives({
       target: containerEl,
+      props: {
+        archives: get(settings).archives,
+        onRestore: (archiveId: ProjectId) => {
+          settings.restoreArchive(archiveId);
+          archivesManager.$set({ archives: get(settings).archives });
+          projectsManager.$set({ projects: get(settings).projects });
+        },
+        onDelete: (archiveId: ProjectId) => {
+          settings.deleteArchive(archiveId);
+          archivesManager.$set({ archives: get(settings).archives });
+        },
+      },
     });
   }
 }


### PR DESCRIPTION
Fixes #559 and responds to #523

### Prototype (Sept 25)
- Restore current project via the three-dots dropdown.
- Use an array `archives` in parallel with `projects` to store the configurations of archived projects.
- Introduced basic UI hooks for listing archived projects in the settings tab.

### Building a Reactive User Interface
- [x] Managing archives and projects in the setting tab.
- [x] Better description, use `an archived project` rather than `an archive`.
- [x] Handle conflicts between dynamic rendering setting tab & project select. This is achieved by manually updating props upon restoration or deletion.
- [x] Ensured unique project names upon restoration to avoid duplicated project names.
 
### Commands Management (Continuing with #699)
- [x] Clean up commands.
- [x] Building tests.