### PR TITLE
Natural sort on strings

### DIFF
--- a/src/ui/app/toolbar/ProjectSelect.svelte
+++ b/src/ui/app/toolbar/ProjectSelect.svelte
@@ -29,7 +29,7 @@
         value: project.id,
       })),
       (draft) => {
-        draft.sort((a, b) => a.label.localeCompare(b.label));
+        draft.sort((a, b) => a.label.localeCompare(b.label, undefined, {numeric: true}));
       }
     )}
     on:change={({ detail: value }) => onProjectChange(value)}

--- a/src/ui/app/viewSort.test.ts
+++ b/src/ui/app/viewSort.test.ts
@@ -311,3 +311,83 @@ describe("applySort", () => {
     });
   });
 });
+
+describe("natural sort", () => {
+  const frame = {
+    fields: [],
+    records: [
+      {
+        id: "Section 1.md",
+        values: {
+          section: "1.Introduction",
+        },
+      },
+      {
+        id: "Section 11.md",
+        values: {
+          section: "11.References",
+        },
+      },
+      {
+        id: "Section 3.md",
+        values: {
+          section: "3.Results",
+        },
+      },
+      {
+        id: "Section 10.md",
+        values: {
+          section: "10.Acknowledgement",
+        },
+      },
+      {
+        id: "Section 2.md",
+        values: {
+          section: "2.Methods",
+        },
+      },
+    ],
+  };
+
+  it("should sort strings containing numbers naturally", () => {
+    const sorted = applySort(frame, {
+      criteria: [{ field: "section", order: "asc", enabled: true }],
+    });
+
+    expect(sorted).toStrictEqual({
+      fields: [],
+      records: [
+        {
+          id: "Section 1.md",
+          values: {
+            section: "1.Introduction",
+          },
+        },
+        {
+          id: "Section 2.md",
+          values: {
+            section: "2.Methods",
+          },
+        },
+        {
+          id: "Section 3.md",
+          values: {
+            section: "3.Results",
+          },
+        },
+        {
+          id: "Section 10.md",
+          values: {
+            section: "10.Acknowledgement",
+          },
+        },
+        {
+          id: "Section 11.md",
+          values: {
+            section: "11.References",
+          },
+        },
+      ],
+    });
+  });
+});

--- a/src/ui/app/viewSort.ts
+++ b/src/ui/app/viewSort.ts
@@ -96,11 +96,7 @@ function sortBoolean(a: boolean, b: boolean, asc: boolean): number {
 }
 
 function sortString(a: string, b: string, asc: boolean): number {
-  if (a < b) {
-    return asc ? -1 : 1;
-  }
-  if (a > b) {
-    return asc ? 1 : -1;
-  }
-  return 0;
+  return asc
+    ? a.localeCompare(b, undefined, { numeric: true })
+    : b.localeCompare(a, undefined, { numeric: true });
 }


### PR DESCRIPTION
Closes #671 

- Natural sort on string values.
- Natural sort on project select.

Utilizing natural sort on filename stays consistent with OS file managers and Obsidian file tree.

**Before**:  [1-Filename, 10-Filename, 100-Filename, 2-Filename, 3-Filename]
**After**: [1-Filename, 2-Filename, 3-Filename, 10-Filename, 100-Filename]