### PR TITLE
Fixed english string resources (EN)

### DIFF
--- a/src/lib/stores/translations/en.json
+++ b/src/lib/stores/translations/en.json
@@ -308,10 +308,10 @@
                 },
                 "include-fields": "Include fields",
                 "settings": {
-                    "name": "画册设置",
+                    "name": "Gallery Settings",
                     "card-width": {
-                        "name": "卡片宽度",
-                        "description": "调整每张卡片的像素宽度。"
+                        "name": "Card width",
+                        "description": "Adjust the pixel width of each card."
                     }
                 },
                 "empty": "This view is empty."

--- a/src/lib/stores/translations/en.json
+++ b/src/lib/stores/translations/en.json
@@ -308,10 +308,10 @@
                 },
                 "include-fields": "Include fields",
                 "settings": {
-                    "name": "Gallery Settings",
+                    "name": "Gallery settings",
                     "card-width": {
                         "name": "Card width",
-                        "description": "Adjust the pixel width of each card."
+                        "description": "Width of each card in pixels."
                     }
                 },
                 "empty": "This view is empty."


### PR DESCRIPTION
Well some of setting description(EN) is written in Chinese instead of English

It seems an easy(?) problem to fix, so did not register an issue.
