### PR TITLE
Add upgrade notice upon first archive

### DIFF
--- a/src/lib/stores/translations/en.json
+++ b/src/lib/stores/translations/en.json
@@ -62,6 +62,7 @@
                     "short-title": "Archive project",
                     "title": "Archive project",
                     "message": "Are you sure you want to archive \"{{project}}\"? You can restore it later in Projects plugin's setting tab.",
+                    "notice": "Project archived! If you are using Projects across multiple devices and syncing between them, please upgrade to version 1.17.0 or above for all your devices to avoid losing your archived project configurations.",
                     "cta": "Archive"
                 },
                 "delete": {

--- a/src/lib/stores/translations/zh-CN.json
+++ b/src/lib/stores/translations/zh-CN.json
@@ -62,6 +62,7 @@
                     "short-title": "存档项目",
                     "title": "存档项目",
                     "message": "确定要存档项目 \"{{project}}\" 吗？若需要，您可以在 Projects 插件设置中恢复该项目。",
+                    "notice": "存档成功！若您在多个设备间同步使用 Projects，请确保将所有设备上的 Projects 都升级到 1.17.0 版本或以上，以避免存档的项目配置信息丢失。",
                     "cta": "存档"
                 },
                 "delete": {

--- a/src/ui/app/toolbar/ProjectSelect.svelte
+++ b/src/ui/app/toolbar/ProjectSelect.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import produce from "immer";
-  import { Menu } from "obsidian";
+  import { Menu, Notice } from "obsidian";
   import { IconButton, Select } from "obsidian-svelte";
 
   import { i18n } from "src/lib/stores/i18n";
@@ -87,6 +87,9 @@
               $i18n.t("modals.project.archive.cta"),
               () => {
                 if (projectId) {
+                  if ($settings.archives.length === 0) {
+                    new Notice($i18n.t("modals.project.archive.notice"), 15000);
+                  }
                   settings.archiveProject(projectId);
                 }
               }


### PR DESCRIPTION
Please upgrade to 1.17.0 or above for your all devices if you are using Projects on multiple devices and syncing between them. Previous versions of Projects cannot recognize `archives` field, and would omit `archives`.