### PR TITLE
Fix board column width reactivity

### DIFF
--- a/src/ui/views/Board/BoardOptionsProvider.svelte
+++ b/src/ui/views/Board/BoardOptionsProvider.svelte
@@ -18,6 +18,8 @@
 
   $: ({ fields } = frame);
 
+  $: columnWidth = config?.columnWidth ?? 270;
+
   function handleIncludedFieldsChange(fields: string[]) {
     onConfigChange({ ...config, includeFields: fields });
   }
@@ -55,6 +57,7 @@
   </ViewHeader>
   <ViewContent>
     <slot
+      {columnWidth}
       groupByField={fields.find((field) => config.groupByField === field.name)}
       includeFields={config.includeFields ?? []}
     />

--- a/src/ui/views/Board/BoardView.svelte
+++ b/src/ui/views/Board/BoardView.svelte
@@ -100,12 +100,13 @@
   {frame}
   config={config ?? {}}
   onConfigChange={saveConfig}
+  let:columnWidth
   let:groupByField
   let:includeFields
 >
   <Board
     columns={getColumns(records, config?.columns ?? {}, groupByField)}
-    columnWidth={config?.columnWidth ?? 270}
+    {columnWidth}
     includeFields={fields.filter((field) => includeFields.includes(field.name))}
     onRecordClick={handleRecordClick}
     onRecordAdd={handleRecordAdd(groupByField)}


### PR DESCRIPTION
Changing column width in board setting modal will now updates the view immediately. This is an expected behavior, like what Gallery view does. Related to #591 and #600.