### PR TITLE
Better visual hint when add-note button is focused

### DIFF
--- a/src/ui/views/Board/components/Board/BoardColumn.svelte
+++ b/src/ui/views/Board/components/Board/BoardColumn.svelte
@@ -19,9 +19,24 @@
   <Typography variant="label" nomargin>{name}</Typography>
   <CardGroup items={records} {onRecordClick} {onDrop} {includeFields} />
   {#if !readonly}
-    <Button variant="plain" on:click={() => onRecordAdd()}>
-      <Icon name="plus" />
-      {$i18n.t("views.board.note.add")}
-    </Button>
+    <span>
+      <Button variant="plain" on:click={() => onRecordAdd()}>
+        <Icon name="plus" />
+        {$i18n.t("views.board.note.add")}
+      </Button>
+    </span>
   {/if}
 </section>
+
+<style>
+  span {
+    display: inline-flex;
+    align-content: center;
+    justify-content: center;
+    border-radius: var(--button-radius);
+  }
+
+  span:focus-within {
+    box-shadow: 0 0 0 2px var(--background-modifier-border-focus);
+  }
+</style>

--- a/src/ui/views/Table/components/DataGrid/DataGrid.svelte
+++ b/src/ui/views/Table/components/DataGrid/DataGrid.svelte
@@ -227,11 +227,16 @@
     />
   {/each}
   <GridCellGroup index={rows.length + 2} footer>
-    <span style={`width: ${60 + (sortedColumns[0]?.width ?? 0)}`}>
-      <Button variant="plain" on:click={() => onRowAdd()}>
-        <Icon name="plus" />
-        {t("components.data-grid.row.add")}
-      </Button>
+    <span
+      class="width-provider"
+      style={`width: ${60 + (sortedColumns[0]?.width ?? 0)}`}
+    >
+      <span class="focus-provider">
+        <Button variant="plain" on:click={() => onRowAdd()}>
+          <Icon name="plus" />
+          {t("components.data-grid.row.add")}
+        </Button>
+      </span>
     </span>
   </GridCellGroup>
 </div>
@@ -241,9 +246,18 @@
     display: inline-block;
   }
 
-  span {
+  .width-provider {
     padding: 4px;
     position: sticky;
     left: 0;
+  }
+
+  .focus-provider {
+    display: inline-flex;
+    border-radius: var(--button-radius);
+  }
+
+  .focus-provider:focus-within {
+    box-shadow: 0 0 0 2px var(--background-modifier-border-focus);
   }
 </style>


### PR DESCRIPTION
When the add-note modal is closed, either by pressing `Enter` or clicking `Save` buttons, the focus will go back to the add-note button on table and board views, if no cell is selected in table view.

This change styles up the add-note buttons when they are focused, indicating users that they can continue to add more notes by another `Enter` press.