### PR TITLE
Relax tagsinput validation

### DIFF
--- a/src/ui/app/toolbar/viewOptions/color/ColorOptions.svelte
+++ b/src/ui/app/toolbar/viewOptions/color/ColorOptions.svelte
@@ -165,7 +165,7 @@
             />
           {:else if isListFilterOperator(rule.condition.operator)}
             <TagsInput
-              strict={true}
+              strict={rule.condition.field === "tags"}
               unique={true}
               value={JSON.parse(rule.condition.value ?? "[]")}
               on:change={(event) => {

--- a/src/ui/app/toolbar/viewOptions/filter/FilterOptions.svelte
+++ b/src/ui/app/toolbar/viewOptions/filter/FilterOptions.svelte
@@ -123,7 +123,7 @@
           />
         {:else if isListFilterOperator(condition.operator)}
           <TagsInput
-            strict={true}
+            strict={condition.field === "tags"}
             unique={true}
             value={JSON.parse(condition.value ?? "[]")}
             on:change={(event) => {

--- a/src/ui/components/TagsInput/TagsInput.svelte
+++ b/src/ui/components/TagsInput/TagsInput.svelte
@@ -9,7 +9,19 @@
   export let unique: boolean = false;
   // check invalid characters for preserved fields
   export let strict: boolean = false;
-  export let invalidChars: string[] = [".", ",", " ", " "]; // ban unintentional nbsp
+  export let invalidChars: string[] = [
+    ".",
+    ",",
+    ";",
+    ":",
+    "#",
+    "<",
+    ">",
+    "?",
+    "\\",
+    " ",
+    " ", // ban unintentional nbsp
+  ];
   export let value: DataValue[];
   let inputRef: HTMLDivElement;
 


### PR DESCRIPTION
Only apply strict validation to tags field in both color conditions and filters.

Mocking tag restrictions. Still not in consistent with official rules. Known problems:
- The leading hash (`#`) will be accepted and deleted in Properties tags input, while Projects will directly ignore this.
- Tags that contains only numbers are invalid, while Projects accept this
 
https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format
https://www.regular-expressions.info/unicode.html