### PR TITLE
Improve i18n

### DIFF
--- a/src/lib/stores/translations/en.json
+++ b/src/lib/stores/translations/en.json
@@ -357,6 +357,10 @@
             "sort": {
                 "label": "Sort",
                 "add": "Add another sort"
+            },
+            "tag": {
+                "edit": "Edit",
+                "remove": "Remove"
             }
         },
         "toolbar": {

--- a/src/lib/stores/translations/en.json
+++ b/src/lib/stores/translations/en.json
@@ -195,7 +195,7 @@
                         "title": "Read-only project",
                         "message": "{{project}} is a read-only project. Select another project to create a note."
                     },
-                    "untitled": "Untitled note"
+                    "untitled": "Untitled"
                 },
                 "edit": {
                     "short-title": "Edit note",

--- a/src/lib/stores/translations/zh-CN.json
+++ b/src/lib/stores/translations/zh-CN.json
@@ -195,7 +195,7 @@
                         "title": "只读项目",
                         "message": "{{project}} 是一个只读项目，请选择其他项目以新建笔记。"
                     },
-                    "untitled": "未命名笔记"
+                    "untitled": "未命名"
                 },
                 "edit": {
                     "short-title": "编辑笔记",

--- a/src/lib/stores/translations/zh-CN.json
+++ b/src/lib/stores/translations/zh-CN.json
@@ -357,6 +357,10 @@
             "sort": {
                 "label": "排序",
                 "add": "添加排序条件"
+            },
+            "tag": {
+                "edit": "编辑",
+                "remove": "移除"
             }
         },
         "toolbar": {

--- a/src/ui/components/TagsInput/Tag/Tag.svelte
+++ b/src/ui/components/TagsInput/Tag/Tag.svelte
@@ -4,6 +4,7 @@
   import type { DataValue } from "src/lib/dataframe/dataframe";
   import { createEventDispatcher } from "svelte";
   import { TagInput } from "../TagInput";
+  import { i18n } from "src/lib/stores/i18n";
 
   export let tag: DataValue;
   export let selected: boolean = false;
@@ -20,7 +21,7 @@
     const menu = new Menu();
     menu.addItem((item) => {
       item
-        .setTitle("Edit")
+        .setTitle($i18n.t("components.tag.edit"))
         .setIcon("edit")
         .onClick((event) => {
           menu.close();
@@ -32,7 +33,7 @@
     menu.addSeparator();
     menu.addItem((item) => {
       item
-        .setTitle("Remove")
+        .setTitle($i18n.t("components.tag.remove"))
         .setIcon("trash-2")
         .onClick((event) => {
           menu.close();


### PR DESCRIPTION
Changes:
- Updated the default filename, to `Untitled` and `未命名` for en and zh, separatedly. This stays consistent with current Obsidian behavior.
- Extracted and translated options in the context menu of tag component that occurs in the newly added tags-input for filters / color conditions.