### PR TITLE
Create field through Table view

### DIFF
--- a/src/lib/dataframe/dataframe.ts
+++ b/src/lib/dataframe/dataframe.ts
@@ -64,6 +64,7 @@ export enum DataFieldType {
   Number = "number",
   Boolean = "boolean",
   Date = "date",
+  List = "multitext",
   Unknown = "unknown",
 }
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -3,6 +3,7 @@ import { get } from "svelte/store";
 
 import { app } from "src/lib/stores/obsidian";
 import type { ProjectDefinition, ViewDefinition } from "src/settings/settings";
+import type { DataField } from "./dataframe/dataframe";
 
 /**
  * notEmpty is a convenience function for filtering arrays with optional values.
@@ -43,12 +44,22 @@ export function nextUniqueProjectName(
 }
 
 /**
- * nextUniqueViewName returns the given project name with the lowest
+ * nextUniqueViewName returns the given view name with the lowest
  * available sequence number appended to it.
  */
 export function nextUniqueViewName(views: ViewDefinition[], name: string) {
   return uniquify(name, (candidate) => {
     return !!views.find((view) => view.name === candidate);
+  });
+}
+
+/**
+ * nextUniqueFieldName returns the given field name with the lowest
+ * available sequence number appended to it.
+ */
+export function nextUniqueFieldName(fields: DataField[], name: string) {
+  return uniquify(name, (candidate) => {
+    return !!fields.find((field) => field.name === candidate);
   });
 }
 

--- a/src/lib/stores/dataframe.ts
+++ b/src/lib/stores/dataframe.ts
@@ -49,6 +49,15 @@ function createDataFrame() {
         })
       );
     },
+    addField(newField: DataField, position?: number) {
+      update((state) =>
+        produce(state, (draft) => {
+          position
+            ? draft.fields.splice(position, 0, newField)
+            : draft.fields.push(newField);
+        })
+      );
+    },
     updateField(updated: DataField, oldName?: string) {
       update((state) =>
         produce(state, (draft) => {

--- a/src/lib/stores/translations/en.json
+++ b/src/lib/stores/translations/en.json
@@ -229,6 +229,34 @@
                         "description": "For fields with Markdown content."
                     },
                     "save": "Save"
+                },
+                "create": {
+                    "short-title": "New field",
+                    "title": "Create new field",
+                    "name": {
+                        "name": "Name",
+                        "description": ""
+                    },
+                    "untitled": "New field",
+                    "empty-name-error": "Field name can't be empty.",
+                    "existing-name-error": "A field with that name already exists.",
+                    "type": {
+                        "name": "Type",
+                        "description": ""
+                    },
+                    "default": {
+                        "name": "Default value",
+                        "description": ""
+                    },
+                    "options": {
+                        "name": "Options",
+                        "description": "Allows you to auto-complete using predefined values for the field."
+                    },
+                    "rich-text": {
+                        "name": "Enable rich text formatting",
+                        "description": "For fields with Markdown content."
+                    },
+                    "create": "Create field"
                 }
             },
             "input": {
@@ -322,6 +350,9 @@
             "data-grid": {
                 "column": {
                     "configure": "Configure field",
+                    "add": "Add field",
+                    "insert-left": "Insert left",
+                    "insert-right": "Insert right",
                     "rename": "Rename field",
                     "delete": "Delete field",
                     "hide": "Hide field"

--- a/src/lib/stores/translations/zh-CN.json
+++ b/src/lib/stores/translations/zh-CN.json
@@ -229,6 +229,34 @@
                         "description": "依照 Markdown 格式渲染字段内容。"
                     },
                     "save": "保存"
+                },
+                "create": {
+                    "short-title": "添加字段",
+                    "title": "添加字段",
+                    "name": {
+                        "name": "字段名称",
+                        "description": ""
+                    },
+                    "untitled": "新字段",
+                    "empty-name-error": "字段名不能为空。",
+                    "existing-name-error": "字段名称重复。",
+                    "type": {
+                        "name": "字段类型",
+                        "description": ""
+                    },
+                    "default": {
+                        "name": "默认值",
+                        "description": ""
+                    },
+                    "options": {
+                        "name": "选项预设",
+                        "description": "在填写该字段内容时，将使用下面提供的预设值进行自动补全。"
+                    },
+                    "rich-text": {
+                        "name": "富文本",
+                        "description": "依照 Markdown 格式渲染字段内容。"
+                    },
+                    "create": "添加字段"
                 }
             },
             "input": {
@@ -322,6 +350,9 @@
             "data-grid": {
                 "column": {
                     "configure": "配置字段",
+                    "add": "新建字段",
+                    "insert-left": "向左插入字段",
+                    "insert-right": "向右插入字段",
                     "rename": "重命名字段",
                     "delete": "删除字段",
                     "hide": "隐藏字段"

--- a/src/lib/viewApi.ts
+++ b/src/lib/viewApi.ts
@@ -1,6 +1,11 @@
 import { get } from "svelte/store";
 
-import type { DataField, DataRecord } from "./dataframe/dataframe";
+import type {
+  DataField,
+  DataRecord,
+  DataValue,
+  Optional,
+} from "./dataframe/dataframe";
 import type { DataApi } from "./dataApi";
 import { dataFrame } from "./stores/dataframe";
 import type { DataSource } from "./datasources";
@@ -30,6 +35,16 @@ export class ViewApi {
       dataFrame.deleteRecord(recordId);
     }
     this.dataApi.deleteRecord(recordId);
+  }
+
+  addField(field: DataField, value: Optional<DataValue>, position?: number) {
+    dataFrame.addField(field, position);
+
+    this.dataApi.addField(
+      get(dataFrame).records.map((record) => record.id),
+      field,
+      value
+    );
   }
 
   updateField(field: DataField, oldName?: string) {

--- a/src/ui/components/TagsInput/Tag/Tag.svelte
+++ b/src/ui/components/TagsInput/Tag/Tag.svelte
@@ -138,8 +138,6 @@
     display: inline-flex;
     align-items: center;
     gap: var(--size-4-1);
-
-    text-wrap: nowrap;
   }
 
   .tag:hover {

--- a/src/ui/components/TagsInput/TagInput/TagInput.svelte
+++ b/src/ui/components/TagsInput/TagInput/TagInput.svelte
@@ -82,7 +82,7 @@
 
 <style>
   div {
-    min-width: 1ch;
+    min-width: 1px;
     max-width: max-content;
     box-sizing: border-box;
 

--- a/src/ui/modals/components/CreateField.svelte
+++ b/src/ui/modals/components/CreateField.svelte
@@ -1,0 +1,312 @@
+<script lang="ts">
+  import {
+    Button,
+    ModalButtonGroup,
+    ModalContent,
+    ModalLayout,
+    Select,
+    SettingItem,
+    TextInput,
+    NumberInput,
+    Switch,
+  } from "obsidian-svelte";
+  import { TagsInput } from "src/ui/components/TagsInput";
+  import MultiTextInput from "src/ui/components/MultiTextInput/MultiTextInput.svelte";
+  import dayjs from "dayjs";
+  import {
+    DataFieldType,
+    type Optional,
+    type DataField,
+    type DataValue,
+  } from "src/lib/dataframe/dataframe";
+  import { i18n } from "src/lib/stores/i18n";
+  import { onMount } from "svelte";
+
+  export let existingFields: DataField[];
+  export let defaultName: string;
+  let inputRef: HTMLInputElement;
+
+  export let field: DataField = {
+    name: defaultName,
+    type: DataFieldType.String,
+    repeated: false,
+    derived: false,
+    identifier: false,
+  };
+
+  let value: Optional<DataValue> = ""; // text, number and boolean
+  let listValue: string = "[]";
+  let dateValue: string = dayjs().format("YYYY-MM-DD");
+
+  export let onCreate: (field: DataField, value: Optional<DataValue>) => void;
+
+  $: fieldNameError = validateFieldName(field.name);
+
+  function validateFieldName(fieldName: string) {
+    if (fieldName.trim() === "") {
+      return $i18n.t("modals.field.create.empty-name-error");
+    }
+
+    if (existingFields.findIndex((field) => field.name === fieldName) !== -1) {
+      return $i18n.t("modals.field.create.existing-name-error");
+    }
+
+    return "";
+  }
+
+  type Conversions = {
+    [K in DataFieldType]: {
+      [L in DataFieldType]: (v: any) => any;
+    };
+  };
+
+  const conversions: Conversions = {
+    [DataFieldType.String]: {
+      [DataFieldType.String]: (v: string) => v,
+      [DataFieldType.Number]: (v: number) => v.toString(),
+      [DataFieldType.Boolean]: (v: boolean) => v.toString(),
+      [DataFieldType.Date]: (v: string) => v.toString(),
+      [DataFieldType.List]: (v: Array<string>) => v.toString(),
+      [DataFieldType.Unknown]: () => null,
+    },
+    [DataFieldType.Number]: {
+      [DataFieldType.String]: (v: string) => parseInt(v),
+      [DataFieldType.Number]: (v: number) => v,
+      [DataFieldType.Boolean]: (v: boolean) => (v ? 1 : 0),
+      [DataFieldType.Date]: (v: string) => dayjs(v).toDate().getTime(),
+      [DataFieldType.List]: (v: Array<string>) => parseInt(v.toString()),
+      [DataFieldType.Unknown]: () => null,
+    },
+    [DataFieldType.Boolean]: {
+      [DataFieldType.String]: (v: string) => !!v,
+      [DataFieldType.Number]: (v: number) => !!v,
+      [DataFieldType.Boolean]: (v: boolean) => v,
+      [DataFieldType.Date]: (v: string) => !!v,
+      [DataFieldType.List]: (v: Array<string>) => !!v.toString(),
+      [DataFieldType.Unknown]: () => null,
+    },
+    [DataFieldType.Date]: {
+      [DataFieldType.String]: (v: string) => dayjs(v).format("YYYY-MM-DD"),
+      [DataFieldType.Number]: (v: number) => dayjs(v).format("YYYY-MM-DD"),
+      [DataFieldType.Boolean]: () => dayjs().format("YYYY-MM-DD"),
+      [DataFieldType.Date]: (v: string) => v,
+      [DataFieldType.List]: (v: Array<string>) =>
+        dayjs(v.toString()).format("YYYY-MM-DD"),
+      [DataFieldType.Unknown]: () => null,
+    },
+    [DataFieldType.List]: {
+      [DataFieldType.String]: (v: string) => [v],
+      [DataFieldType.Number]: (v: number) => [v],
+      [DataFieldType.Boolean]: (v: boolean) => [v],
+      [DataFieldType.Date]: (v: string) => [v],
+      [DataFieldType.List]: (v: Array<string>) => v,
+      [DataFieldType.Unknown]: () => null,
+    },
+    [DataFieldType.Unknown]: {
+      [DataFieldType.String]: () => null,
+      [DataFieldType.Number]: () => null,
+      [DataFieldType.Boolean]: () => null,
+      [DataFieldType.Date]: () => null,
+      [DataFieldType.List]: () => null,
+      [DataFieldType.Unknown]: () => null,
+    },
+  };
+
+  function convert(
+    origValue: Optional<DataValue>,
+    from: DataFieldType,
+    to: DataFieldType
+  ) {
+    if (origValue === undefined || origValue === null) {
+      return null;
+    }
+
+    // list and date uses separated values to avoid conversion runs into chaos
+    if (
+      to === DataFieldType.List ||
+      to === DataFieldType.Date ||
+      from === DataFieldType.List ||
+      from === DataFieldType.Date
+    ) {
+      return origValue;
+    }
+
+    return conversions[to][from](origValue);
+  }
+
+  function handleTypeChange(event: CustomEvent<string>) {
+    const from = field.type;
+    const to = event.detail as DataFieldType;
+    if (to === DataFieldType.List) {
+      field = {
+        ...field,
+        type: to,
+        repeated: true,
+      };
+    } else {
+      value = convert(value, from, to);
+      field = {
+        ...field,
+        type: to,
+        repeated: false,
+      };
+    }
+  }
+
+  function handleOptionsChange(textOptions: string[]) {
+    field = {
+      ...field,
+      typeConfig: {
+        ...field.typeConfig,
+        options: textOptions,
+      },
+    };
+  }
+
+  function handleRichTextChange({ detail: richText }: CustomEvent<boolean>) {
+    field = {
+      ...field,
+      typeConfig: {
+        ...field.typeConfig,
+        richText,
+      },
+    };
+  }
+
+  const options = [
+    { label: $i18n.t("data-types.string"), value: DataFieldType.String },
+    { label: $i18n.t("data-types.number"), value: DataFieldType.Number },
+    { label: $i18n.t("data-types.boolean"), value: DataFieldType.Boolean },
+    { label: $i18n.t("data-types.date"), value: DataFieldType.Date },
+    { label: $i18n.t("data-types.list"), value: DataFieldType.List },
+  ];
+
+  onMount(() => {
+    if (inputRef) inputRef.select();
+  });
+</script>
+
+<ModalLayout title={$i18n.t("modals.field.create.title")}>
+  <ModalContent>
+    <SettingItem
+      name={$i18n.t("modals.field.create.name.name")}
+      description={$i18n.t("modals.field.create.name.description") ?? ""}
+    >
+      <TextInput
+        bind:ref={inputRef}
+        value={field.name}
+        on:input={(event) => (field = { ...field, name: event.detail })}
+        autoFocus
+        error={!!fieldNameError}
+        helperText={fieldNameError}
+        on:keydown={(ev) => {
+          if (ev.key === "Enter" && !fieldNameError) {
+            ev.preventDefault();
+            onCreate(field, value);
+          }
+        }}
+      />
+    </SettingItem>
+
+    <SettingItem
+      name={$i18n.t("modals.field.create.type.name")}
+      description={$i18n.t("modals.field.create.type.description")}
+    >
+      <Select value={field.type} {options} on:change={handleTypeChange} />
+    </SettingItem>
+
+    <SettingItem
+      name={$i18n.t("modals.field.create.default.name")}
+      description={$i18n.t("modals.field.create.default.description")}
+    >
+      {#if field.type === DataFieldType.List}
+        <TagsInput
+          value={JSON.parse(listValue)}
+          on:change={(event) => {
+            listValue = event.detail;
+          }}
+        />
+      {:else if field.type === DataFieldType.String}
+        <TextInput
+          value={value?.toString() ?? ""}
+          on:input={(event) => (value = event.detail)}
+          on:keydown={(ev) => {
+            if (ev.key === "Enter" && !fieldNameError) {
+              ev.preventDefault();
+              onCreate(field, value);
+            }
+          }}
+        />
+      {:else if field.type === DataFieldType.Number}
+        <NumberInput
+          bind:ref={inputRef}
+          value={parseInt((value ?? "").toString())}
+          on:input={(event) => (value = event.detail)}
+          on:keydown={(ev) => {
+            if (ev.key === "Enter" && !fieldNameError) {
+              ev.preventDefault();
+              onCreate(field, value);
+            }
+          }}
+        />
+      {:else if field.type === DataFieldType.Date}
+        <input
+          type="date"
+          bind:value={dateValue}
+          on:change={(ev) => {
+            dateValue = ev.currentTarget.value;
+          }}
+          max="9999-12-31"
+        />
+      {:else if field.type === DataFieldType.Boolean}
+        <Switch
+          checked={value ? true : false}
+          on:check={(ev) => {
+            value = ev.detail;
+          }}
+        />
+      {/if}
+    </SettingItem>
+    {#if !field.repeated && field.type === DataFieldType.String}
+      <SettingItem
+        name={$i18n.t("modals.field.create.options.name")}
+        description={$i18n.t("modals.field.create.options.description")}
+        vertical
+      >
+        <MultiTextInput
+          options={field.typeConfig?.options ?? []}
+          onChange={handleOptionsChange}
+        />
+      </SettingItem>
+      <SettingItem
+        name={$i18n.t("modals.field.configure.rich-text.name")}
+        description={$i18n.t("modals.field.configure.rich-text.description")}
+      >
+        <Switch
+          checked={field.typeConfig?.richText ?? false}
+          on:check={handleRichTextChange}
+        />
+      </SettingItem>
+    {/if}
+  </ModalContent>
+  <ModalButtonGroup>
+    <Button
+      variant={"primary"}
+      disabled={!!fieldNameError}
+      on:click={() => {
+        if (field.repeated) {
+          onCreate(
+            { ...field, type: DataFieldType.String }, // remove the temporary `list` type declaration
+            JSON.parse(listValue)
+          );
+        } else if (field.type === DataFieldType.Date) {
+          onCreate(field, dateValue);
+        } else {
+          onCreate(field, value);
+        }
+      }}
+    >
+      {$i18n.t("modals.field.create.create")}
+    </Button>
+  </ModalButtonGroup>
+</ModalLayout>

--- a/src/ui/modals/createFieldModal.ts
+++ b/src/ui/modals/createFieldModal.ts
@@ -1,0 +1,47 @@
+import { App, Modal } from "obsidian";
+import { get } from "svelte/store";
+
+import { i18n } from "src/lib/stores/i18n";
+import { nextUniqueFieldName } from "src/lib/helpers";
+
+import CreateField from "./components/CreateField.svelte";
+import type {
+  DataField,
+  DataValue,
+  Optional,
+} from "src/lib/dataframe/dataframe";
+
+export class CreateFieldModal extends Modal {
+  component?: CreateField;
+
+  constructor(
+    app: App,
+    readonly fields: DataField[],
+    readonly onCreate: (field: DataField, value: Optional<DataValue>) => void
+  ) {
+    super(app);
+  }
+
+  onOpen() {
+    this.component = new CreateField({
+      target: this.contentEl,
+      props: {
+        existingFields: this.fields,
+        defaultName: nextUniqueFieldName(
+          this.fields,
+          get(i18n).t("modals.field.create.untitled")
+        ),
+        onCreate: (field: DataField, value: Optional<DataValue>) => {
+          this.onCreate(field, value);
+          this.close();
+        },
+      },
+    });
+  }
+
+  onClose() {
+    if (this.component) {
+      this.component.$destroy();
+    }
+  }
+}

--- a/src/ui/views/Table/TableView.svelte
+++ b/src/ui/views/Table/TableView.svelte
@@ -118,8 +118,9 @@
         behavior: "smooth",
       });
 
-      const orderFields = fields.map((field) => field.name);
-      orderFields.filter((f) => f !== field.name);
+      const orderFields = fields
+        .map((field) => field.name)
+        .filter((f) => f !== field.name);
       orderFields.push(field.name);
       saveConfig({
         ...config,
@@ -135,8 +136,9 @@
       const position = fields.findIndex((f) => anchor === f.name) + direction;
       await api.addField(field, value, position);
 
-      const orderFields = fields.map((field) => field.name);
-      orderFields.filter((f) => f !== field.name);
+      const orderFields = fields
+        .map((field) => field.name)
+        .filter((f) => f !== field.name);
       orderFields.splice(position, 0, field.name);
       saveConfig({
         ...config,

--- a/src/ui/views/Table/TableView.svelte
+++ b/src/ui/views/Table/TableView.svelte
@@ -261,6 +261,7 @@
                       [field.name]: field.typeConfig,
                     },
                   });
+                  saveConfig({ ...config });
                 }
               }
             ).open();

--- a/src/ui/views/Table/TableView.svelte
+++ b/src/ui/views/Table/TableView.svelte
@@ -110,6 +110,9 @@
 
   function handleColumnAdd() {
     new CreateFieldModal($app, fields, async (field, value) => {
+      const orderFields = fields.map((field) => field.name);
+      orderFields.filter((f) => f !== field.name);
+
       await api.addField(field, value);
 
       buttonEl.scrollIntoView({
@@ -118,9 +121,7 @@
         behavior: "smooth",
       });
 
-      const orderFields = fields.map((field) => field.name);
       orderFields.push(field.name);
-
       saveConfig({
         ...config,
         orderFields: orderFields,
@@ -145,13 +146,13 @@
   }
 
   function handleColumnInsert(anchor: string, direction: number) {
-    const position =
-      fields.findIndex((field) => anchor === field.name) + direction;
-
     new CreateFieldModal($app, fields, async (field, value) => {
+      const orderFields = fields.map((field) => field.name);
+      orderFields.filter((f) => f !== field.name);
+      const position = fields.findIndex((f) => anchor === f.name) + direction;
+
       await api.addField(field, value, position);
 
-      const orderFields = fields.map((field) => field.name);
       orderFields.splice(position, 0, field.name);
 
       saveConfig({

--- a/src/ui/views/Table/TableView.svelte
+++ b/src/ui/views/Table/TableView.svelte
@@ -112,22 +112,15 @@
   function handleColumnAppend() {
     new CreateFieldModal($app, fields, async (field, value) => {
       await api.addField(field, value);
+
       buttonEl.scrollIntoView({
         block: "nearest",
         inline: "nearest",
         behavior: "smooth",
       });
 
-      const orderFields = fields
-        .map((field) => field.name)
-        .filter((f) => f !== field.name);
-      orderFields.push(field.name);
-      saveConfig({
-        ...config,
-        orderFields: orderFields,
-      });
-
-      handleFieldAdd(field);
+      updateFieldCfg(field);
+      updateViewCfg(field);
     }).open();
   }
 
@@ -136,20 +129,12 @@
       const position = fields.findIndex((f) => anchor === f.name) + direction;
       await api.addField(field, value, position);
 
-      const orderFields = fields
-        .map((field) => field.name)
-        .filter((f) => f !== field.name);
-      orderFields.splice(position, 0, field.name);
-      saveConfig({
-        ...config,
-        orderFields: orderFields,
-      });
-
-      handleFieldAdd(field);
+      updateFieldCfg(field);
+      updateViewCfg(field, position);
     }).open();
   }
 
-  function handleFieldAdd(field: DataField) {
+  function updateFieldCfg(field: DataField) {
     const projectFields = Object.fromEntries(
       Object.entries(project.fieldConfig ?? {}).filter(([key, _]) =>
         fields.find((f) => f.name === key && f.name !== field.name)
@@ -172,6 +157,26 @@
         },
       });
     }
+  }
+
+  function updateViewCfg(field: DataField, position?: number) {
+    const orderFields = fields
+      .map((field) => field.name)
+      .filter((f) => f !== field.name);
+
+    orderFields.splice(position ?? orderFields.length, 0, field.name);
+
+    const tableFields = Object.fromEntries(
+      Object.entries(config?.fieldConfig ?? {}).filter(([key, _]) =>
+        fields.find((f) => f.name === key && f.name !== field.name)
+      )
+    );
+
+    saveConfig({
+      ...config,
+      orderFields: orderFields,
+      fieldConfig: { ...tableFields },
+    });
   }
 </script>
 

--- a/src/ui/views/Table/components/DataGrid/DataGrid.svelte
+++ b/src/ui/views/Table/components/DataGrid/DataGrid.svelte
@@ -30,6 +30,10 @@
   export let onColumnConfigure: (column: GridColDef, editable: boolean) => void;
   export let onColumnDelete: (field: string) => void;
   export let onColumnHide: (column: GridColDef) => void;
+  export let onColumnInsert: (
+    anchor: string, // anchor field name
+    direction: number // 1 for right, 0 for left insert (keep the place and push back others)
+  ) => void;
   export let onRowDelete: (rowId: GridRowId) => void;
   export let onRowEdit: (rowId: GridRowId, row: GridRowModel) => void;
 
@@ -53,6 +57,37 @@
         .onClick(() => onColumnConfigure(column, editable));
     });
 
+    if (!readonly) {
+      menu.addItem((item) => {
+        item
+          .setTitle(t("components.data-grid.column.insert-left"))
+          .setIcon("arrow-left")
+          .onClick(() => {
+            onColumnInsert(column.field, 0);
+          });
+      });
+
+      menu.addItem((item) => {
+        item
+          .setTitle(t("components.data-grid.column.insert-right"))
+          .setIcon("arrow-right")
+          .onClick(() => {
+            onColumnInsert(column.field, 1);
+          });
+      });
+    }
+
+    menu.addSeparator();
+
+    menu.addItem((item) => {
+      item
+        .setTitle(t("components.data-grid.column.hide"))
+        .setIcon("eye-off")
+        .onClick(() => {
+          onColumnHide(column);
+        });
+    });
+
     if (editable) {
       menu.addItem((item) => {
         item
@@ -60,8 +95,6 @@
           .setIcon("trash")
           .onClick(() => onColumnDelete(column.field));
       });
-
-      menu.addSeparator();
     }
 
     // let isDateCol = column.type === DataFieldType.Date;
@@ -92,15 +125,6 @@
     // });
     //
     // menu.addSeparator();
-
-    menu.addItem((item) => {
-      item
-        .setTitle(t("components.data-grid.column.hide"))
-        .setIcon("eye-off")
-        .onClick(() => {
-          onColumnHide(column);
-        });
-    });
 
     return menu;
   }

--- a/src/ui/views/Table/components/DataGrid/DataGrid.svelte
+++ b/src/ui/views/Table/components/DataGrid/DataGrid.svelte
@@ -97,35 +97,6 @@
       });
     }
 
-    // let isDateCol = column.type === DataFieldType.Date;
-    //
-    // menu.addItem((item) => {
-    //   item
-    //     .setTitle(
-    //       t(
-    //         isDateCol
-    //           ? "components.data-grid.sortDate.asc"
-    //           : "components.data-grid.sort.asc"
-    //       )
-    //     )
-    //     .setIcon("sort-asc")
-    //     .onClick(() => onSortModelChange(column.field, "asc"));
-    // });
-    // menu.addItem((item) => {
-    //   item
-    //     .setTitle(
-    //       t(
-    //         isDateCol
-    //           ? "components.data-grid.sortDate.desc"
-    //           : "components.data-grid.sort.desc"
-    //       )
-    //     )
-    //     .setIcon("sort-desc")
-    //     .onClick(() => onSortModelChange(column.field, "desc"));
-    // });
-    //
-    // menu.addSeparator();
-
     return menu;
   }
 


### PR DESCRIPTION
Updates #692, #709, #197

This PR allows creating new fields in Table view directly, via the `Add field` button at the end of columns, or `Insert left/right` button provided in the column drop-down (`three-dots`).

Important change on dataframe:
- Introduced a new field type `List`, and encode as `multitext`, stay in consistent with Obsidian (see undocumented [obsidian-typings](https://github.com/Fevol/obsidian-typings))
  - Currently `multitext` support is still inplemented by `repeted` text field