### PR TITLE
Introduce the new `render` method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "i18next": "^21.9.2",
         "immer": "^9.0.15",
         "jest": "^29.3.1",
-        "obsidian": "latest",
+        "obsidian": "^1.4.11",
         "obsidian-dataview": "^0.5.46",
         "obsidian-svelte": "0.1.10",
         "prettier": "^2.8.1",
@@ -7223,12 +7223,12 @@
       }
     },
     "node_modules/obsidian": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.2.3.tgz",
-      "integrity": "sha512-v0RIu/M6kPCbamkIpH1L2wHG0W79qK0GYaPCbBzR3Rb08glbPSStPPRcd3ZVV/c547AEwLIbi8XjNO+HlFftnA==",
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.4.11.tgz",
+      "integrity": "sha512-BCVYTvaXxElJMl6MMbDdY/CGK+aq18SdtDY/7vH8v6BxCBQ6KF4kKxL0vG9UZ0o5qh139KpUoJHNm+6O5dllKA==",
       "dev": true,
       "dependencies": {
-        "@types/codemirror": "0.0.108",
+        "@types/codemirror": "5.60.8",
         "moment": "2.29.4"
       },
       "peerDependencies": {
@@ -7320,6 +7320,15 @@
       "dev": true,
       "dependencies": {
         "dayjs": "^1.11.6"
+      }
+    },
+    "node_modules/obsidian/node_modules/@types/codemirror": {
+      "version": "5.60.8",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+      "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
+      "dev": true,
+      "dependencies": {
+        "@types/tern": "*"
       }
     },
     "node_modules/once": {
@@ -14872,13 +14881,24 @@
       }
     },
     "obsidian": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.2.3.tgz",
-      "integrity": "sha512-v0RIu/M6kPCbamkIpH1L2wHG0W79qK0GYaPCbBzR3Rb08glbPSStPPRcd3ZVV/c547AEwLIbi8XjNO+HlFftnA==",
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.4.11.tgz",
+      "integrity": "sha512-BCVYTvaXxElJMl6MMbDdY/CGK+aq18SdtDY/7vH8v6BxCBQ6KF4kKxL0vG9UZ0o5qh139KpUoJHNm+6O5dllKA==",
       "dev": true,
       "requires": {
-        "@types/codemirror": "0.0.108",
+        "@types/codemirror": "5.60.8",
         "moment": "2.29.4"
+      },
+      "dependencies": {
+        "@types/codemirror": {
+          "version": "5.60.8",
+          "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+          "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
+          "dev": true,
+          "requires": {
+            "@types/tern": "*"
+          }
+        }
       }
     },
     "obsidian-calendar-ui": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "i18next": "^21.9.2",
     "immer": "^9.0.15",
     "jest": "^29.3.1",
-    "obsidian": "latest",
+    "obsidian": "^1.4.11",
     "obsidian-dataview": "^0.5.46",
     "obsidian-svelte": "0.1.10",
     "prettier": "^2.8.1",

--- a/src/ui/components/CardMetadata/Text.svelte
+++ b/src/ui/components/CardMetadata/Text.svelte
@@ -14,7 +14,7 @@
 
   function useMarkdown(node: HTMLElement) {
     if (typeof value === "string") {
-      MarkdownRenderer.renderMarkdown(value, node, sourcePath, $view);
+      MarkdownRenderer.render($app, value, node, sourcePath, $view);
     }
   }
 

--- a/src/ui/views/Board/components/Board/ColumnHeader.svelte
+++ b/src/ui/views/Board/components/Board/ColumnHeader.svelte
@@ -9,12 +9,12 @@
   const sourcePath = getContext<string>("sourcePath") ?? "";
 
   function useMarkdown(node: HTMLElement, value: string) {
-    MarkdownRenderer.renderMarkdown(value, node, sourcePath, $view);
+    MarkdownRenderer.render($app, value, node, sourcePath, $view);
 
     return {
       update(newValue: string) {
         node.empty();
-        MarkdownRenderer.renderMarkdown(newValue, node, sourcePath, $view);
+        MarkdownRenderer.render($app, newValue, node, sourcePath, $view);
       },
     };
   }

--- a/src/ui/views/Table/components/DataGrid/GridCell/GridTextCell/TextLabel.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridCell/GridTextCell/TextLabel.svelte
@@ -9,12 +9,12 @@
   const sourcePath = getContext<string>("sourcePath") ?? "";
 
   function useMarkdown(node: HTMLElement, value: string) {
-    MarkdownRenderer.renderMarkdown(value, node, sourcePath, $view);
+    MarkdownRenderer.render($app, value, node, sourcePath, $view);
 
     return {
       update(newValue: string) {
         node.empty();
-        MarkdownRenderer.renderMarkdown(newValue, node, sourcePath, $view);
+        MarkdownRenderer.render($app, newValue, node, sourcePath, $view);
       },
     };
   }


### PR DESCRIPTION
Closes #427

The updates on obsidian-api brings the `MarkdownRenderer.render` method, and the `renderMarkdown` is deprecated. It allows the `![[link | width]]` style for the embeds! By this PR, you can playing around with more powerful rich-text elements!

![image](https://github.com/marcusolsson/obsidian-projects/assets/73122375/eee3cf9e-f8a7-44fe-8b2c-bc0f21b95a2b)

### Known issue
- Need to handle clicking preview of img elements, as it would interferes the dblclick in-place edit.
