### PR TITLE
docs(bug-report.yml): update description for Obsidian version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -42,7 +42,7 @@ body:
     id: obsidianVersion
     attributes:
       label: Obsidian version
-      description: You can find the version under Settings -> About -> Current version.
+      description: You can find the version under Settings -> General -> Current version.
     validations:
       required: true
 


### PR DESCRIPTION
the "About" section of Settings was renamed to "General" in v1.5.2 `catalyst`, soon it will be moved to `public`

https://obsidian.md/changelog/2023-12-12-desktop-v1.5.2/