### PR TITLE
Fix add templated note with empty `tags` field in tag based project

### DIFF
--- a/src/lib/dataApi.ts
+++ b/src/lib/dataApi.ts
@@ -95,10 +95,15 @@ export class DataApi {
             content,
             decodeFrontMatter,
             E.map((frontmatter) => frontmatter["tags"]),
-            E.getOrElse(() => [])
+            E.fold(
+              () => [],
+              (right) => right ?? [] // handle `null`
+            )
           );
           //@ts-ignore explict input in `createDataRecord()`
-          const tagSet = new Set(templateTags.concat(record.values["tags"]));
+          const tagSet: Set<string> = new Set(
+            templateTags.concat(record.values["tags"])
+          );
           record.values["tags"] = [...tagSet];
         }
       }


### PR DESCRIPTION
Fixes #798 

Added `null` check and provided `[]` fallback.