### PR TITLE
Allow rich text rendering for list tags

### DIFF
--- a/src/ui/components/TagList/TagList.svelte
+++ b/src/ui/components/TagList/TagList.svelte
@@ -8,8 +8,10 @@
 
   import { app } from "src/lib/stores/obsidian";
   import { InputDialogModal } from "src/ui/modals/inputDialog";
+  import RichTextTag from "src/ui/views/Table/components/DataGrid/GridCell/GridListCell/RichTextTag.svelte";
 
   export let values: Optional<DataValue>[];
+  export let richText: boolean = false;
   export let edit: boolean = false;
 
   export let onChange: (values: Optional<DataValue>[]) => void = () => {};
@@ -43,7 +45,7 @@
     />
   {:else}
     {#each values as value}
-      <Tag>{value}</Tag>
+      <RichTextTag {richText} value={value?.toString() ?? ""} />
     {/each}
   {/if}
 </div>

--- a/src/ui/modals/components/ConfigureField.svelte
+++ b/src/ui/modals/components/ConfigureField.svelte
@@ -102,6 +102,17 @@
         />
       </SettingItem>
     {/if}
+    {#if field.type === DataFieldType.String && field.repeated && !field.identifier}
+      <SettingItem
+        name={$i18n.t("modals.field.configure.rich-text.name")}
+        description={$i18n.t("modals.field.configure.rich-text.description")}
+      >
+        <Switch
+          checked={field.typeConfig?.richText ?? false}
+          on:check={handleRichTextChange}
+        />
+      </SettingItem>
+    {/if}
   </ModalContent>
   <ModalButtonGroup>
     <Button

--- a/src/ui/views/Table/components/DataGrid/GridCell/GridListCell/GridListCell.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridCell/GridListCell/GridListCell.svelte
@@ -13,6 +13,11 @@
 </script>
 
 <GridCell {selected} {rowindex} {colindex} {column} on:mousedown on:navigate>
-  <TagList slot="read" edit={false} values={value || []} />
+  <TagList
+    slot="read"
+    edit={false}
+    values={value || []}
+    richText={column.typeConfig?.richText ?? false}
+  />
   <TagList slot="edit" edit={true} values={value || []} {onChange} />
 </GridCell>

--- a/src/ui/views/Table/components/DataGrid/GridCell/GridListCell/RichTextTag.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridCell/GridListCell/RichTextTag.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { MarkdownRenderer } from "obsidian";
+  import { view } from "src/lib/stores/obsidian";
+  import { getContext } from "svelte";
+  const sourcePath = getContext<string>("sourcePath") ?? "";
+
+  import { app } from "src/lib/stores/obsidian";
+
+  export let value: string;
+  export let richText: boolean = false;
+
+  function useMarkdown(node: HTMLElement, value: string) {
+    MarkdownRenderer.renderMarkdown(value, node, sourcePath, $view);
+
+    return {
+      update(newValue: string) {
+        node.empty();
+        MarkdownRenderer.renderMarkdown(newValue, node, sourcePath, $view);
+      },
+    };
+  }
+
+  function handleClick(event: MouseEvent) {
+    const targetEl = event.target as HTMLElement;
+    const closestAnchor =
+      targetEl.tagName === "A" ? targetEl : targetEl.closest("a");
+
+    if (!closestAnchor) {
+      return;
+    }
+
+    if (closestAnchor.hasClass("internal-link")) {
+      event.preventDefault();
+
+      const href = closestAnchor.getAttr("href");
+      const newLeaf = event.button === 1 || event.ctrlKey || event.metaKey;
+
+      if (href) {
+        $app.workspace.openLinkText(href, sourcePath, newLeaf);
+      }
+    }
+  }
+</script>
+
+{#if richText}
+  <div use:useMarkdown={value} on:click={handleClick} on:keypress />
+{:else}
+  <div>{value}</div>
+{/if}
+
+<style>
+  div {
+    background-color: var(--tag-background);
+    border: var(--tag-border-width) solid var(--tag-border-color);
+    border-radius: var(--tag-radius);
+    color: var(--tag-color);
+    font-size: var(--tag-size);
+    text-decoration: var(--tag-decoration);
+    padding: var(--tag-padding-y) var(--tag-padding-x);
+    line-height: 1;
+
+    display: inline-flex;
+    align-items: center;
+    gap: var(--size-4-1);
+  }
+
+  div :global(p:first-child) {
+    margin-top: 0;
+  }
+
+  div :global(p:last-child) {
+    margin-bottom: 0;
+  }
+</style>


### PR DESCRIPTION
Fixes #756. Now the list field also allows the `richText` option in the Table view column setting modal.

<img src="https://github.com/marcusolsson/obsidian-projects/assets/73122375/bcd11ee1-a308-4f95-be30-8f26978b842a" width="600"/>

### Limitation

Now the deprecated `MarkdownRender.renderMarkdown` method rather than `render` is used, to avoid elements like note page and images being rendered. Will find way to identify which elements should be rendered in list tags.