### PR TITLE
Fix hover on link in a table row

### DIFF
--- a/src/ui/views/Table/components/DataGrid/GridRow.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridRow.svelte
@@ -71,7 +71,7 @@
     if (file instanceof TFile) {
       $app.workspace.trigger("hover-link", {
         event,
-        source: `obsidian-projects-table-view`,
+        source: "obsidian-projects-table-view",
         hoverParent: anchor,
         targetEl,
         linktext: file.name,

--- a/src/ui/views/Table/components/DataGrid/GridRow.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridRow.svelte
@@ -60,21 +60,23 @@
       return;
     }
 
-    const targetEl = event.target;
+    const targetEl = event.target as HTMLDivElement;
+    const anchor =
+      targetEl.tagName === "A" ? targetEl : targetEl.querySelector("a");
+    if (!anchor || !anchor.hasClass("internal-link")) return;
 
-    if (targetEl instanceof HTMLDivElement) {
-      const file = $app.vault.getAbstractFileByPath(rowId);
+    const href = anchor.getAttr("href");
+    const file = href && $app.metadataCache.getFirstLinkpathDest(href, rowId);
 
-      if (file instanceof TFile) {
-        $app.workspace.trigger("hover-link", {
-          event,
-          source: "obsidian-projects-table-view",
-          hoverParent: targetEl.parentElement,
-          targetEl,
-          linktext: file.name,
-          sourcePath: file.path,
-        });
-      }
+    if (file instanceof TFile) {
+      $app.workspace.trigger("hover-link", {
+        event,
+        source: `obsidian-projects-table-view`,
+        hoverParent: anchor,
+        targetEl,
+        linktext: file.name,
+        sourcePath: file.path,
+      });
     }
   }
 </script>


### PR DESCRIPTION
Previously, hovering on any link cell in table view with `ctrl` / `meta` key pressed will always show the preview of the row file, rather than the correct destination of the link. Now this is fixed.