### PR TITLE
Decouple field operations in Table view

### DIFF
--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -16,6 +16,7 @@ import {
   type ProjectId,
   type ProjectsPluginPreferences,
   type ProjectsPluginSettings,
+  type FieldConfig,
   type ViewDefinition,
   type ViewId,
 } from "src/settings/settings";
@@ -122,6 +123,36 @@ function createSettings() {
       update((state) =>
         produce(state, (draft) => {
           draft.projects = draft.projects.filter((w) => w.id !== projectId);
+        })
+      );
+    },
+    updateFieldConfig(
+      projectId: ProjectId,
+      fieldName: string,
+      config: FieldConfig
+    ) {
+      update((state) =>
+        produce(state, (draft) => {
+          draft.projects = draft.projects.map((project) => {
+            if (project.id === projectId) {
+              return {
+                ...project,
+                fieldConfig: {
+                  ...project.fieldConfig,
+                  [fieldName]: config,
+                },
+              };
+            }
+            return project;
+          });
+        })
+      );
+    },
+    deleteFieldConfig(projectId: ProjectId, fieldName: string) {
+      update((state) =>
+        produce(state, (draft) => {
+          const project = draft.projects.find((p) => p.id === projectId);
+          if (project) delete project.fieldConfig[fieldName];
         })
       );
     },

--- a/src/lib/stores/translations/en.json
+++ b/src/lib/stores/translations/en.json
@@ -216,6 +216,8 @@
                         "name": "Name",
                         "description": ""
                     },
+                    "empty-name-error": "Field name can't be empty.",
+                    "existing-name-error": "Can't rename to a existing field name.",
                     "type": {
                         "name": "Type",
                         "description": "Changing type isn't supported yet."

--- a/src/lib/stores/translations/zh-CN.json
+++ b/src/lib/stores/translations/zh-CN.json
@@ -216,6 +216,8 @@
                         "name": "字段名称",
                         "description": ""
                     },
+                    "empty-name-error": "字段名不能为空。",
+                    "existing-name-error": "不能重命名为已有字段。",
                     "type": {
                         "name": "字段类型",
                         "description": "尚不支持修改字段类型。"
@@ -228,7 +230,7 @@
                         "name": "富文本",
                         "description": "依照 Markdown 格式渲染字段内容。"
                     },
-                    "save": "保存"
+                    "save": "保存修改"
                 },
                 "create": {
                     "short-title": "添加字段",

--- a/src/ui/modals/components/ConfigureField.svelte
+++ b/src/ui/modals/components/ConfigureField.svelte
@@ -16,7 +16,19 @@
   export let title: string;
   export let field: DataField;
   export let editable: boolean;
+  export let existingFields: DataField[];
   export let onSave: (field: DataField) => void;
+
+  $: fieldNameError = validateFieldName(field.name);
+
+  function validateFieldName(fieldName: string) {
+    if (fieldName.trim() === "") {
+      return $i18n.t("modals.field.configure.empty-name-error");
+    }
+    if (existingFields.findIndex((field) => field.name === fieldName) !== -1)
+      return $i18n.t("modals.field.configure.existing-name-error");
+    return "";
+  }
 
   function handleNameChange(value: CustomEvent<string>) {
     field = {
@@ -67,6 +79,8 @@
       <TextInput
         readonly={!editable}
         value={field.name}
+        error={!!fieldNameError}
+        helperText={fieldNameError}
         on:input={handleNameChange}
       />
     </SettingItem>
@@ -106,6 +120,7 @@
   <ModalButtonGroup>
     <Button
       variant="primary"
+      disabled={!!fieldNameError}
       on:click={() => {
         onSave(field);
       }}>{$i18n.t("modals.field.configure.save")}</Button

--- a/src/ui/modals/configureField.ts
+++ b/src/ui/modals/configureField.ts
@@ -10,6 +10,7 @@ export class ConfigureFieldModal extends Modal {
     app: App,
     readonly title: string,
     readonly field: DataField,
+    readonly existingFields: DataField[],
     readonly editable: boolean,
     readonly onSave: (field: DataField) => void
   ) {
@@ -22,6 +23,7 @@ export class ConfigureFieldModal extends Modal {
       props: {
         title: this.title,
         field: this.field,
+        existingFields: this.existingFields,
         editable: this.editable,
         onSave: (field: DataField) => {
           this.onSave(field);

--- a/src/ui/views/Table/TableView.svelte
+++ b/src/ui/views/Table/TableView.svelte
@@ -237,6 +237,7 @@
               $app,
               $i18n.t("modals.field.configure.title"),
               field,
+              fields.filter((f) => f.name !== field.name),
               editable,
               (field) => {
                 if (editable) {

--- a/src/ui/views/Table/TableView.svelte
+++ b/src/ui/views/Table/TableView.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import {
     DataFieldType,
-    type DataField,
     type DataFrame,
     type DataRecord,
   } from "src/lib/dataframe/dataframe";
@@ -119,8 +118,9 @@
         behavior: "smooth",
       });
 
-      updateFieldCfg(field);
-      updateViewCfg(field);
+      if (field.typeConfig) {
+        settings.updateFieldConfig(project.id, field.name, field.typeConfig);
+      }
     }).open();
   }
 
@@ -129,48 +129,52 @@
       const position = fields.findIndex((f) => anchor === f.name) + direction;
       await api.addField(field, value, position);
 
-      updateFieldCfg(field);
-      updateViewCfg(field, position);
+      if (field.typeConfig) {
+        settings.updateFieldConfig(project.id, field.name, field.typeConfig);
+      }
+
+      const orderFields = fields
+        .map((f) => f.name)
+        .filter((f) => f !== field.name);
+      if (position) orderFields.splice(position, 0, field.name);
+
+      saveConfig({
+        ...config,
+        orderFields: orderFields,
+      });
     }).open();
   }
 
-  function updateFieldCfg(field: DataField) {
-    const projectFields = Object.fromEntries(
-      Object.entries(project.fieldConfig ?? {}).filter(([key, _]) =>
-        fields.find((f) => f.name === key && f.name !== field.name)
-      )
-    );
-
-    if (field.typeConfig) {
-      settings.updateProject({
-        ...project,
-        fieldConfig: {
-          ...projectFields,
-          [field.name]: field.typeConfig,
-        },
-      });
-    } else {
-      settings.updateProject({
-        ...project,
-        fieldConfig: {
-          ...projectFields,
-        },
-      });
-    }
-  }
-
-  function updateViewCfg(field: DataField, position?: number) {
+  function deleteColumnConfig(fieldName: string) {
     const orderFields = fields
       .map((field) => field.name)
-      .filter((f) => f !== field.name);
+      .filter((f) => f !== fieldName);
 
-    orderFields.splice(position ?? orderFields.length, 0, field.name);
+    const tableFields = { ...config?.fieldConfig };
+    delete tableFields[fieldName];
 
-    const tableFields = Object.fromEntries(
-      Object.entries(config?.fieldConfig ?? {}).filter(([key, _]) =>
-        fields.find((f) => f.name === key && f.name !== field.name)
-      )
-    );
+    saveConfig({
+      ...config,
+      orderFields: orderFields,
+      fieldConfig: { ...tableFields },
+    });
+  }
+
+  // update view-level config (width, hidden, order etc.) on column rename
+  function renameColumnConfig(newName: string, oldName: string) {
+    const orderFields = fields.map((field) => field.name);
+    const idx = orderFields.findIndex((f) => f === oldName);
+    if (idx >= 0) orderFields.splice(idx, 1, newName);
+
+    const tableFields = { ...config?.fieldConfig };
+
+    if (config?.fieldConfig) {
+      const oldConfig = config?.fieldConfig[oldName];
+      if (oldConfig) {
+        tableFields[newName] = oldConfig;
+        delete tableFields[oldName];
+      }
+    }
 
     saveConfig({
       ...config,
@@ -243,33 +247,32 @@
                 if (editable) {
                   if (field.name !== column.field) {
                     api.updateField(field, column.field);
+                    renameColumnConfig(field.name, column.field);
+                    settings.deleteFieldConfig(project.id, column.field);
                   } else {
                     api.updateField(field);
                   }
                 }
 
-                const projectFields = Object.fromEntries(
-                  Object.entries(project.fieldConfig ?? {}).filter(([key, _]) =>
-                    fields.find((field) => field.name === key)
-                  )
-                );
-
                 if (field.typeConfig) {
-                  settings.updateProject({
-                    ...project,
-                    fieldConfig: {
-                      ...projectFields,
-                      [field.name]: field.typeConfig,
-                    },
-                  });
-                  saveConfig({ ...config });
+                  settings.updateFieldConfig(
+                    project.id,
+                    field.name,
+                    field.typeConfig
+                  );
                 }
+
+                saveConfig({ ...config });
               }
             ).open();
           }
         }}
         onColumnInsert={handleColumnInsert}
-        onColumnDelete={(field) => api.deleteField(field)}
+        onColumnDelete={(field) => {
+          api.deleteField(field);
+          settings.deleteFieldConfig(project.id, field);
+          deleteColumnConfig(field);
+        }}
         onRowChange={(rowId, row) => {
           api.updateRecord({ id: rowId, values: row }, fields);
         }}


### PR DESCRIPTION
Fixes #733, fixes #757, and updates #709

### Changes

- Delete field will now
  - delete its project-level config (rich-text, options, etc.)
  - delete its table view-leval config (column width, column orders, etc.)
- Rename field will now
  - keep its column order
  - (existing feature) keep its project-level config
  - keep its width
  - no longer revert view renaming or filter modifications
  - no longer accepts empty name or existing field name
- Change field config will
  - no longer revert view renaming
- Add / insert field will
  - no longer revert view renaming