### PR TITLE
Board: header overflow, column orders, and clean up column configs

### DIFF
--- a/src/ui/views/Board/BoardOptionsProvider.svelte
+++ b/src/ui/views/Board/BoardOptionsProvider.svelte
@@ -26,6 +26,7 @@
 
   function handleStatusFieldChange(field: DataField | undefined) {
     const { groupByField, ...rest } = config;
+    delete rest.columns;
 
     onConfigChange(field ? { ...rest, groupByField: field.name } : { ...rest });
   }

--- a/src/ui/views/Board/BoardView.svelte
+++ b/src/ui/views/Board/BoardView.svelte
@@ -28,6 +28,7 @@
     OnSortColumns,
   } from "./components/Board/types";
   import type { BoardConfig } from "./types";
+  import { settings } from "src/lib/stores/settings";
 
   export let project: ProjectDefinition;
   export let frame: DataFrame;
@@ -206,17 +207,27 @@
       }).open();
     };
 
-  const handleSortColumns: OnSortColumns = (names) => {
-    saveConfig({
-      ...config,
-      columns: Object.fromEntries(
-        names.map((name, i) => [
-          name,
-          { ...config?.columns?.[name], weight: i },
-        ])
-      ),
-    });
-  };
+  const handleSortColumns =
+    (field: DataField | undefined): OnSortColumns =>
+    (names) => {
+      if (field?.name && field?.typeConfig) {
+        settings.updateFieldConfig(project.id, field?.name, {
+          ...field.typeConfig,
+          options: [...(field.typeConfig?.options ?? [])].sort(
+            (a, b) => names.indexOf(a) - names.indexOf(b)
+          ),
+        });
+      }
+      saveConfig({
+        ...config,
+        columns: Object.fromEntries(
+          names.map((name, i) => [
+            name,
+            { ...config?.columns?.[name], weight: i },
+          ])
+        ),
+      });
+    };
 
   function saveConfig(cfg: BoardConfig) {
     config = cfg;
@@ -250,7 +261,7 @@
     onRecordClick={handleRecordClick}
     onRecordAdd={handleRecordAdd(groupByField)}
     onRecordUpdate={handleRecordUpdate(groupByField)}
-    onSortColumns={handleSortColumns}
+    onSortColumns={handleSortColumns(groupByField)}
     {readonly}
     richText={groupByField?.typeConfig?.richText ?? false}
   />

--- a/src/ui/views/Board/components/Board/ColumnHeader.svelte
+++ b/src/ui/views/Board/components/Board/ColumnHeader.svelte
@@ -50,6 +50,11 @@
 {/if}
 
 <style>
+  div {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   div :global(p:first-child) {
     margin-top: 0;
   }


### PR DESCRIPTION
Follow-ups on #788 

### Column header overflow

Set text overflow style for column header.

### Board column orders

Now the order of columns follows user custom sorting first. By default, when there's no custom sorting, the columns registered in field predefined values go first and share the same order with the values. The remain columns are natural alphabetical sorted. This should eliminate unstable column order on file moving between columns.

Sorting between predefined values will update the sequence back. However, custom sorting information would lost if you change to another status field and then shift back.

### Cleanup column configs

Clean up all column details (i.e. the record orders and column orders) when changing status field (namely the groupByField).