### PR TITLE
Cancel hard coded path in `name` field

### DIFF
--- a/src/lib/datasources/frontmatter/datasource.ts
+++ b/src/lib/datasources/frontmatter/datasource.ts
@@ -125,7 +125,7 @@ export async function standardizeRecords(
         E.map((values) => ({
           ...values,
           path: file.path,
-          name: `[[${file.path}|${file.basename}]]`,
+          name: `[[${file.basename}]]`,
         })),
         E.map((values) => standardizeRecord(file.path, values))
       );


### PR DESCRIPTION
Fixes #820 

This change affects folder and tags datasources.

Previously, the name field is encoded as `[[file.path|file.basename]]`, and the sorting and filtering took the path into accouts. When the notes are placed in multiple folders, (e.g. subfolders for folder-based projects, and the vault-global tag projects), sorting and filtering won't follow the display text in the `name` field.

Now the path is omitted and the name field is defined as `[[file.basename]]`. Clicking or hovering over the link won't be affected as we resolve the link destination based on the row path.

For dataview users, the same goes for the default `File` identifier column. Sorting on this will also give wrong results if your notes are stored in multiple folders. Please use the following query to build a new custom column, and sort/filter on this.

```dataview
TABLE file.name as [custom_name]
```