### PR TITLE
Fix link parsing for gallery view

### DIFF
--- a/src/ui/views/Gallery/gallery.ts
+++ b/src/ui/views/Gallery/gallery.ts
@@ -22,9 +22,6 @@ export function getCoverRealPath(
   }
 
   if (isString(coverPath)) {
-    if (coverPath.startsWith("http://") || coverPath.startsWith("https://")) {
-      return coverPath;
-    }
     return getResourcePathFromLinkText(app, coverPath);
   }
 
@@ -33,6 +30,9 @@ export function getCoverRealPath(
 
 function getResourcePathFromLinkText(app: App, text: string) {
   const linkText = parseObsidianLink(text)?.linkText || text;
+  if (linkText.startsWith("http://") || linkText.startsWith("https://")) {
+    return linkText;
+  }
 
   const file = app.metadataCache.getFirstLinkpathDest(linkText, "");
 

--- a/src/ui/views/Gallery/helpers.test.ts
+++ b/src/ui/views/Gallery/helpers.test.ts
@@ -6,17 +6,63 @@ describe("parseObsidianLink", () => {
     expect(parseObsidianLink("Untitled")).toBeNull();
   });
 
-  it("parses simple link", () => {
+  it("parses simple wiki link", () => {
     expect(parseObsidianLink("[[Untitled]]")).toStrictEqual({
       linkText: "Untitled",
       displayName: "",
     });
   });
 
-  it("parses link with display name", () => {
+  it("parses wiki link with display name", () => {
     expect(parseObsidianLink("[[Untitled|Foo]]")).toStrictEqual({
       linkText: "Untitled",
       displayName: "Foo",
+    });
+  });
+
+  it("parses simple wiki link embed", () => {
+    expect(parseObsidianLink("![[Untitled]]")).toStrictEqual({
+      linkText: "Untitled",
+      displayName: "",
+    });
+  });
+
+  it("parses wiki link embed with display name", () => {
+    expect(parseObsidianLink("![[Untitled|Foo]]")).toStrictEqual({
+      linkText: "Untitled",
+      displayName: "Foo",
+    });
+  });
+
+  it("parse simple markdown link", () => {
+    expect(parseObsidianLink("[](obsidian-icon.png)")).toStrictEqual({
+      linkText: "obsidian-icon.png",
+      displayName: "",
+    });
+  });
+
+  it("parse markdown link with display name", () => {
+    expect(
+      parseObsidianLink("[my awesome cover](obsidian-icon.png)")
+    ).toStrictEqual({
+      linkText: "obsidian-icon.png",
+      displayName: "my awesome cover",
+    });
+  });
+
+  it("parse simple markdown link embed", () => {
+    expect(parseObsidianLink("![](obsidian-icon.png)")).toStrictEqual({
+      linkText: "obsidian-icon.png",
+      displayName: "",
+    });
+  });
+
+  it("parse markdown link embed with display name", () => {
+    expect(
+      parseObsidianLink("[my awesome cover](obsidian-icon.png)")
+    ).toStrictEqual({
+      linkText: "obsidian-icon.png",
+      displayName: "my awesome cover",
     });
   });
 });

--- a/src/ui/views/Gallery/helpers.ts
+++ b/src/ui/views/Gallery/helpers.ts
@@ -1,15 +1,24 @@
-const obsidianLinkRegExp = /^\[\[(.*?)(\|(.*?))?\]\]$/;
+const wikiLinkRegExp = /^\!?\[\[(.*?)(\|(.*?))?\]\]$/;
+const mdLinkRegExp = /^\!?\[([^\[]*)\]\((.*)\)$/;
 
 export function parseObsidianLink(link: string): {
   linkText: string;
   displayName: string;
 } | null {
-  const match = link.match(obsidianLinkRegExp);
+  const wikiLink = link.match(wikiLinkRegExp);
+  const mdLink = link.match(mdLinkRegExp);
 
-  return match
-    ? {
-        linkText: match[1] || "",
-        displayName: match[3] || "",
-      }
-    : null;
+  if (wikiLink) {
+    return {
+      linkText: wikiLink[1] || "",
+      displayName: wikiLink[3] || "",
+    };
+  } else if (mdLink) {
+    return {
+      linkText: mdLink[2] || "",
+      displayName: mdLink[1] || "",
+    };
+  } else {
+    return null;
+  }
 }


### PR DESCRIPTION
Fixes: #424 

Now all formats below can be recognized

- Wiki link: `[[internal link|text]]`
- Markdown link: `[text](internal link)`
- External link: `[text](web link)`
- Plain web link: `https://...` & `http://...`

Display texts are all optional, and the corresponding embed verision (e.g. `![[internal link]]`) is supported.