### PR TITLE
Fix non-folder based project won't listen to file deletion

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -28,7 +28,13 @@ export function registerFileEvents(watcher: IFileSystemWatcher) {
 
   watcher.onDelete(async (file) => {
     withDataSource(async (source) => {
+      const recordExists = !!get(dataFrame).records.find(
+        (record) => record.id === file.path
+      );
+
       if (source.includes(file.path)) {
+        dataFrame.deleteRecord(file.path);
+      } else if (recordExists) {
         dataFrame.deleteRecord(file.path);
       }
     });

--- a/src/events.ts
+++ b/src/events.ts
@@ -32,9 +32,7 @@ export function registerFileEvents(watcher: IFileSystemWatcher) {
         (record) => record.id === file.path
       );
 
-      if (source.includes(file.path)) {
-        dataFrame.deleteRecord(file.path);
-      } else if (recordExists) {
+      if (recordExists) {
         dataFrame.deleteRecord(file.path);
       }
     });


### PR DESCRIPTION
Directly check if the dataframe contains a record with the same path with the deleted one. The previous version only works for folder based projects.