### PR TITLE
Pin (lock, freeze) table columns

### DIFF
--- a/src/lib/stores/translations/en.json
+++ b/src/lib/stores/translations/en.json
@@ -360,8 +360,10 @@
                     "insert-left": "Insert left",
                     "insert-right": "Insert right",
                     "rename": "Rename field",
-                    "delete": "Delete field",
-                    "hide": "Hide field"
+                    "pin-field": "Pin field",
+                    "unpin-field": "Unpin field",
+                    "hide": "Hide field",
+                    "delete": "Delete field"
                 },
                 "row": {
                     "add": "Add note",

--- a/src/lib/stores/translations/zh-CN.json
+++ b/src/lib/stores/translations/zh-CN.json
@@ -360,8 +360,10 @@
                     "insert-left": "向左插入字段",
                     "insert-right": "向右插入字段",
                     "rename": "重命名字段",
-                    "delete": "删除字段",
-                    "hide": "隐藏字段"
+                    "pin-field": "固定字段",
+                    "unpin-field": "取消固定",
+                    "hide": "隐藏字段",
+                    "delete": "删除字段"
                 },
                 "row": {
                     "add": "新建笔记",

--- a/src/ui/views/Table/TableView.svelte
+++ b/src/ui/views/Table/TableView.svelte
@@ -71,6 +71,7 @@
         field: field.name,
         width: fieldConfig[field.name]?.width ?? 180,
         hide: fieldConfig[field.name]?.hide ?? false,
+        pinned: fieldConfig[field.name]?.pinned ?? false,
         editable: !field.derived,
       };
 
@@ -103,6 +104,19 @@
         [field]: {
           ...fieldConfig[field],
           width,
+        },
+      },
+    });
+  }
+
+  function handleColumnPin(field: string, pinned: boolean | undefined) {
+    saveConfig({
+      ...config,
+      fieldConfig: {
+        ...fieldConfig,
+        [field]: {
+          ...fieldConfig[field],
+          pinned: !pinned,
         },
       },
     });
@@ -233,6 +247,7 @@
         }}
         onRowDelete={(id) => api.deleteRecord(id)}
         onColumnHide={(column) => handleVisibilityChange(column.field, false)}
+        onColumnPin={(column) => handleColumnPin(column.field, column.pinned)}
         onColumnConfigure={(column, editable) => {
           const field = fields.find((field) => field.name === column.field);
 

--- a/src/ui/views/Table/components/DataGrid/DataGrid.svelte
+++ b/src/ui/views/Table/components/DataGrid/DataGrid.svelte
@@ -30,6 +30,7 @@
   export let onColumnConfigure: (column: GridColDef, editable: boolean) => void;
   export let onColumnDelete: (field: string) => void;
   export let onColumnHide: (column: GridColDef) => void;
+  export let onColumnPin: (column: GridColDef) => void;
   export let onColumnInsert: (
     anchor: string, // anchor field name
     direction: number // 1 for right, 0 for left insert (keep the place and push back others)
@@ -81,6 +82,17 @@
 
     menu.addItem((item) => {
       item
+        .setTitle(
+          column.pinned
+            ? t("components.data-grid.column.unpin-field")
+            : t("components.data-grid.column.pin-field")
+        )
+        .setIcon(column.pinned ? "pin-off" : "pin")
+        .onClick(() => onColumnPin(column));
+    });
+
+    menu.addItem((item) => {
+      item
         .setTitle(t("components.data-grid.column.hide"))
         .setIcon("eye-off")
         .onClick(() => {
@@ -93,7 +105,8 @@
         item
           .setTitle(t("components.data-grid.column.delete"))
           .setIcon("trash")
-          .onClick(() => onColumnDelete(column.field));
+          .onClick(() => onColumnDelete(column.field))
+          .setWarning(true);
       });
     }
 
@@ -117,7 +130,8 @@
         item
           .setTitle(t("components.data-grid.row.delete"))
           .setIcon("trash")
-          .onClick(() => onRowDelete(rowId));
+          .onClick(() => onRowDelete(rowId))
+          .setWarning(true);
       });
     }
 

--- a/src/ui/views/Table/components/DataGrid/DataGrid.svelte
+++ b/src/ui/views/Table/components/DataGrid/DataGrid.svelte
@@ -105,8 +105,7 @@
         item
           .setTitle(t("components.data-grid.column.delete"))
           .setIcon("trash")
-          .onClick(() => onColumnDelete(column.field))
-          .setWarning(true);
+          .onClick(() => onColumnDelete(column.field));
       });
     }
 
@@ -130,8 +129,7 @@
         item
           .setTitle(t("components.data-grid.row.delete"))
           .setIcon("trash")
-          .onClick(() => onRowDelete(rowId))
-          .setWarning(true);
+          .onClick(() => onRowDelete(rowId));
       });
     }
 

--- a/src/ui/views/Table/components/DataGrid/GridCell/GridCell.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridCell/GridCell.svelte
@@ -167,6 +167,7 @@
     class:selected
     class:rowHeader
     class:columnHeader
+    class:pinned={column.pinned}
     style={`width: ${column.width}px`}
     tabindex={!columnHeader && !rowHeader ? 1 : undefined}
     on:click={handleClick}
@@ -227,8 +228,8 @@
   }
 
   .selected {
-    box-shadow: 0 0 0 3px var(--interactive-accent);
-    z-index: 4;
+    box-shadow: 0 0 0 2px inset var(--interactive-accent);
+    border-radius: var(--radius-s);
     padding: 0;
   }
 
@@ -255,5 +256,12 @@
     padding: 3px;
     gap: 4px;
     position: sticky;
+  }
+
+  .pinned {
+    left: 60px;
+    background-color: var(--background-secondary);
+    position: sticky;
+    border-right: 1px solid var(--background-modifier-border-focus);
   }
 </style>

--- a/src/ui/views/Table/components/DataGrid/GridHeader/GridColumnHeader.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridHeader/GridColumnHeader.svelte
@@ -26,6 +26,7 @@
   role="columnheader"
   aria-colindex={colindex}
   style:width={`${column.width}px`}
+  class:pinned={column.pinned}
 >
   {#if column.repeated}
     {#if column.field == "tags"}
@@ -72,5 +73,9 @@
     padding: 0 4px;
 
     cursor: default;
+  }
+
+  div.pinned {
+    border-right: 1px solid var(--background-modifier-border-focus);
   }
 </style>

--- a/src/ui/views/Table/components/DataGrid/GridHeader/GridHeader.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridHeader/GridHeader.svelte
@@ -42,7 +42,11 @@
     on:finalize={handleDndFinalize}
   >
     {#each columns as column, columnIdx (column.id)}
-      <div class={`flex relative`} animate:flip={{ duration: flipDurationMs }}>
+      <div
+        class={`flex relative`}
+        animate:flip={{ duration: flipDurationMs }}
+        class:pinned={column.pinned}
+      >
         <GridColumnHeader {column} {onColumnMenu} colindex={columnIdx} />
         <Resizer
           width={column.width ?? 180}
@@ -86,5 +90,11 @@
     position: sticky;
     left: 0px;
     top: 0px;
+  }
+
+  div.pinned {
+    left: 60px;
+    z-index: 6;
+    position: sticky;
   }
 </style>

--- a/src/ui/views/Table/components/DataGrid/dataGrid.ts
+++ b/src/ui/views/Table/components/DataGrid/dataGrid.ts
@@ -11,6 +11,7 @@ export interface GridColDef extends DataField {
   readonly hide?: boolean;
   readonly editable?: boolean;
   readonly header?: boolean;
+  readonly pinned?: boolean;
 }
 
 export type GridRowId = string;

--- a/src/ui/views/Table/types.ts
+++ b/src/ui/views/Table/types.ts
@@ -2,6 +2,7 @@ export interface FieldConfig {
   readonly [key: string]: {
     readonly width?: number;
     readonly hide?: boolean;
+    readonly pinned?: boolean;
   };
 }
 


### PR DESCRIPTION
Closes #351 

### Feature

This PR allows table columns be pinned / unpinned through the three-dot dropdown menu. You can pin any visible columns and they will stop at the table beginning when you scroll horizontally ahead.

<img src="https://github.com/marcusolsson/obsidian-projects/assets/73122375/546e2ea8-26f6-47d4-a505-236f80b28e57" width="500"/>

If multiple columns are pinned, the the column on the right will stack over the previous pinned column, and also be fixed at the table beginning.

<img src="https://github.com/marcusolsson/obsidian-projects/assets/73122375/d5ab4def-bfb7-40f4-b82b-f5698ddb5fd5" width="500"/>

> [!Note]
> The style of selected cell is adapted, to avoid handling complex stackings. Now the highlight border is inside the cell and thinner than before.