### PR TITLE
Always conduct numeric locale compare between strings

### DIFF
--- a/src/lib/datasources/dataview/datasource.ts
+++ b/src/lib/datasources/dataview/datasource.ts
@@ -100,7 +100,7 @@ export class DataviewDataSource extends DataSource {
           return distance;
         }
 
-        return a.name.localeCompare(b.name);
+        return a.name.localeCompare(b.name, undefined, { numeric: true });
       });
     });
   }

--- a/src/lib/datasources/frontmatter/datasource.ts
+++ b/src/lib/datasources/frontmatter/datasource.ts
@@ -100,7 +100,7 @@ export abstract class FrontMatterDataSource extends DataSource {
           return 1;
         }
 
-        return a.name.localeCompare(b.name);
+        return a.name.localeCompare(b.name, undefined, { numeric: true });
       });
     });
   }

--- a/src/ui/views/Board/board.ts
+++ b/src/ui/views/Board/board.ts
@@ -75,7 +75,7 @@ export function getColumns(
         if (aIndex >= 0 && bIndex >= 0) return aIndex - bIndex;
         else if (aIndex >= 0) return -1;
         else if (bIndex >= 0) return 1;
-        else return a.localeCompare(b);
+        else return a.localeCompare(b, undefined, { numeric: true });
       }
     })
     .map((column) => {


### PR DESCRIPTION
Board and table columns should follow numeric string compare order by default. (Also known as natural sort)

Follow-up on PR #694 and the corresponding issue #671. You can read more about this design there.