### PR TITLE
Fix popover components in new window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "jest": "^29.3.1",
         "obsidian": "^1.4.11",
         "obsidian-dataview": "^0.5.46",
-        "obsidian-svelte": "0.1.10",
+        "obsidian-svelte": "0.2.1",
         "prettier": "^2.8.1",
         "prettier-plugin-svelte": "^2.9.0",
         "sass": "^1.63.6",
@@ -7314,9 +7314,9 @@
       }
     },
     "node_modules/obsidian-svelte": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/obsidian-svelte/-/obsidian-svelte-0.1.10.tgz",
-      "integrity": "sha512-GqdCFO93YtdKiQv+UNrNYyvIrCBuNmOMd9+ju1wm2wEM8GyB/ryRURtX8/j6z+Shr1pT4qeeWmmf/sjFwUVipA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/obsidian-svelte/-/obsidian-svelte-0.2.1.tgz",
+      "integrity": "sha512-FA9mdvgtUi13PAA77Nw9BV3A4Hm8095V94ZTFNNIDmEdo2cp0AW4Zq/doWCjD0Zi4hQMLqMn9qAJapxTzQe+SQ==",
       "dev": true,
       "dependencies": {
         "dayjs": "^1.11.6"
@@ -14972,9 +14972,9 @@
       }
     },
     "obsidian-svelte": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/obsidian-svelte/-/obsidian-svelte-0.1.10.tgz",
-      "integrity": "sha512-GqdCFO93YtdKiQv+UNrNYyvIrCBuNmOMd9+ju1wm2wEM8GyB/ryRURtX8/j6z+Shr1pT4qeeWmmf/sjFwUVipA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/obsidian-svelte/-/obsidian-svelte-0.2.1.tgz",
+      "integrity": "sha512-FA9mdvgtUi13PAA77Nw9BV3A4Hm8095V94ZTFNNIDmEdo2cp0AW4Zq/doWCjD0Zi4hQMLqMn9qAJapxTzQe+SQ==",
       "dev": true,
       "requires": {
         "dayjs": "^1.11.6"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jest": "^29.3.1",
     "obsidian": "^1.4.11",
     "obsidian-dataview": "^0.5.46",
-    "obsidian-svelte": "0.1.10",
+    "obsidian-svelte": "0.2.1",
     "prettier": "^2.8.1",
     "prettier-plugin-svelte": "^2.9.0",
     "sass": "^1.63.6",


### PR DESCRIPTION
Fixes #784 and follow-up PR #829 by upgrade `obsidian-svelte` lib.

Ref
- https://github.com/marcusolsson/obsidian-svelte/pull/5 
- https://github.com/marcusolsson/obsidian-svelte/pull/6

Now filters, colors & toggle menu should work in new window hosted projects.