### PR TITLE
Fix non-md file present in Projects upon filesystem events

### DIFF
--- a/src/lib/filesystem/obsidian/filesystem.ts
+++ b/src/lib/filesystem/obsidian/filesystem.ts
@@ -16,7 +16,7 @@ class ObsidianFile extends IFile {
   static of(path: string, app: App): IFile {
     const file = app.vault.getAbstractFileByPath(normalizePath(path));
 
-    if (file instanceof TFile) {
+    if (file instanceof TFile && file.extension === "md") {
       return new ObsidianFile(file, app);
     }
 
@@ -112,7 +112,7 @@ export class ObsidianFileSystemWatcher implements IFileSystemWatcher {
   onCreate(callback: (file: IFile) => Promise<void>): void {
     this.plugin.registerEvent(
       this.plugin.app.vault.on("create", (file) => {
-        if (file instanceof TFile) {
+        if (file instanceof TFile && file.extension === "md") {
           callback(new ObsidianFile(file, app));
         }
       })
@@ -123,7 +123,7 @@ export class ObsidianFileSystemWatcher implements IFileSystemWatcher {
   onChange(callback: (file: IFile) => Promise<void>): void {
     this.plugin.registerEvent(
       this.plugin.app.metadataCache.on("changed", (file) => {
-        if (file instanceof TFile) {
+        if (file instanceof TFile && file.extension === "md") {
           callback(new ObsidianFile(file, app));
         }
       })
@@ -134,7 +134,7 @@ export class ObsidianFileSystemWatcher implements IFileSystemWatcher {
   onDelete(callback: (file: IFile) => Promise<void>): void {
     this.plugin.registerEvent(
       this.plugin.app.vault.on("delete", (file) => {
-        if (file instanceof TFile) {
+        if (file instanceof TFile && file.extension === "md") {
           callback(new ObsidianFile(file, app));
         }
       })
@@ -145,7 +145,7 @@ export class ObsidianFileSystemWatcher implements IFileSystemWatcher {
   onRename(callback: (file: IFile, oldPath: string) => Promise<void>): void {
     this.plugin.registerEvent(
       this.plugin.app.vault.on("rename", (file, oldPath) => {
-        if (file instanceof TFile) {
+        if (file instanceof TFile && file.extension === "md") {
           callback(new ObsidianFile(file, app), oldPath);
         }
       })


### PR DESCRIPTION
Fixes #831 

Besides moving in (`rename` event essentialy), creating file externally could in a tracked folder would also let non-md file visible in Projects.

Non-md file that already exists in the tracked folder won't be recognized, see following lines. So for filesystem listener, it should also only listen to `md` file related events.
https://github.com/marcusolsson/obsidian-projects/blob/46097d907639cd280ebd41d0b8b61f38e4b4320b/src/lib/filesystem/obsidian/filesystem.ts#L98-L103
