### PR TITLE
Remove config of missing field upon field update

### DIFF
--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -1,4 +1,4 @@
-import produce, { castDraft, castImmutable } from "immer";
+import produce, { castImmutable } from "immer";
 import { writable } from "svelte/store";
 import { v4 as uuidv4 } from "uuid";
 

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -1,4 +1,4 @@
-import produce from "immer";
+import produce, { castDraft, castImmutable } from "immer";
 import { writable } from "svelte/store";
 import { v4 as uuidv4 } from "uuid";
 
@@ -129,12 +129,19 @@ function createSettings() {
     updateFieldConfig(
       projectId: ProjectId,
       fieldName: string,
+      fields: string[],
       config: FieldConfig
     ) {
       update((state) =>
         produce(state, (draft) => {
           draft.projects = draft.projects.map((project) => {
             if (project.id === projectId) {
+              if (project.fieldConfig) {
+                Object.keys(castImmutable(project).fieldConfig)
+                  .filter((k) => !fields.includes(k))
+                  .forEach((k) => delete project.fieldConfig[k]);
+              }
+
               return {
                 ...project,
                 fieldConfig: {

--- a/src/ui/views/Board/BoardView.svelte
+++ b/src/ui/views/Board/BoardView.svelte
@@ -211,12 +211,17 @@
     (field: DataField | undefined): OnSortColumns =>
     (names) => {
       if (field?.name && field?.typeConfig) {
-        settings.updateFieldConfig(project.id, field?.name, {
-          ...field.typeConfig,
-          options: [...(field.typeConfig?.options ?? [])].sort(
-            (a, b) => names.indexOf(a) - names.indexOf(b)
-          ),
-        });
+        settings.updateFieldConfig(
+          project.id,
+          field?.name,
+          fields.map((f) => f.name),
+          {
+            ...field.typeConfig,
+            options: [...(field.typeConfig?.options ?? [])].sort(
+              (a, b) => names.indexOf(a) - names.indexOf(b)
+            ),
+          }
+        );
       }
       saveConfig({
         ...config,

--- a/src/ui/views/Table/TableView.svelte
+++ b/src/ui/views/Table/TableView.svelte
@@ -133,7 +133,12 @@
       });
 
       if (field.typeConfig) {
-        settings.updateFieldConfig(project.id, field.name, field.typeConfig);
+        settings.updateFieldConfig(
+          project.id,
+          field.name,
+          fields.map((f) => f.name),
+          field.typeConfig
+        );
       }
     }).open();
   }
@@ -144,7 +149,12 @@
       await api.addField(field, value, position);
 
       if (field.typeConfig) {
-        settings.updateFieldConfig(project.id, field.name, field.typeConfig);
+        settings.updateFieldConfig(
+          project.id,
+          field.name,
+          fields.map((f) => f.name),
+          field.typeConfig
+        );
       }
 
       const orderFields = fields
@@ -273,6 +283,7 @@
                   settings.updateFieldConfig(
                     project.id,
                     field.name,
+                    fields.map((f) => f.name),
                     field.typeConfig
                   );
                 }


### PR DESCRIPTION
If we delete all the notes that contains a certain field, the dataframe won't take it into count any more, but the stored project-level config will stay. When we create the field again in note (external change to Projects plugin), the stored config would take effect unexpectedly.

So here each time the field config updates, Projects will retrieve dataframe fields and remove the stale field configs.