### PR TITLE
Standardize Link in dataview query result list

### DIFF
--- a/src/lib/datasources/dataview/standardize.ts
+++ b/src/lib/datasources/dataview/standardize.ts
@@ -1,10 +1,6 @@
 import dayjs from "dayjs";
 import type { Link } from "obsidian-dataview";
-import {
-  isRepeatedDataValue,
-  type DataValue,
-  type Optional,
-} from "src/lib/dataframe/dataframe";
+import type { DataValue, Optional } from "src/lib/dataframe/dataframe";
 
 /**
  * standardizeValues converts a Dataview data structure of values to the common
@@ -22,19 +18,24 @@ export function standardizeValues(
       return;
     }
 
-    if (isRepeatedDataValue(value)) {
+    if (Array.isArray(value)) {
+      value.map((v) => (typeof v === "object" ? standardizeObject(v) : v));
       res[field] = value;
     } else if (typeof value === "object") {
-      if ("path" in value && "display" in value) {
-        res[field] = (value as Link).toString();
-      }
-      if ("ts" in value) {
-        res[field] = dayjs(value.ts).format("YYYY-MM-DD");
-      }
+      res[field] = standardizeObject(value);
     } else {
       res[field] = value;
     }
   });
 
   return res;
+}
+
+function standardizeObject(value: any) {
+  if ("path" in value && "display" in value) {
+    return (value as Link).toString();
+  }
+  if ("ts" in value) {
+    return dayjs(value.ts).format("YYYY-MM-DD");
+  }
 }


### PR DESCRIPTION
Closes #729

Previously, when standardize dataview querying result, the link nested in array is ignored.