### PR TITLE
Fix table name link

### DIFF
--- a/src/lib/datasources/frontmatter/datasource.ts
+++ b/src/lib/datasources/frontmatter/datasource.ts
@@ -125,7 +125,7 @@ export async function standardizeRecords(
         E.map((values) => ({
           ...values,
           path: file.path,
-          name: `[[${file.basename}]]`,
+          name: `[[${file.path}|${file.basename}]]`,
         })),
         E.map((values) => standardizeRecord(file.path, values))
       );

--- a/src/ui/app/viewSort.ts
+++ b/src/ui/app/viewSort.ts
@@ -69,6 +69,12 @@ function sortCriteria(
   aval = aval?.toString().toLocaleLowerCase() ?? "";
   bval = bval?.toString().toLocaleLowerCase() ?? "";
 
+  const nameLinkRegExp = /^\[\[(.*?)\|(.*?)\]\]$/;
+  if (criteria.field === "name") {
+    aval = aval.match(nameLinkRegExp)?.[2] || aval;
+    bval = bval.match(nameLinkRegExp)?.[2] || bval;
+  }
+
   return sortString(aval, bval, isAsc);
 }
 


### PR DESCRIPTION
Fixes #862

The path info is added back to the name field. Now, to correctly sort files by name, an extra validation is added when sorting records.