### PR TITLE
Fix Enter key activates read-only cell editing

### DIFF
--- a/src/ui/views/Table/components/DataGrid/GridCell/GridCell.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridCell/GridCell.svelte
@@ -69,7 +69,7 @@
           onEditChange(false);
           ref.focus();
         } else {
-          onEditChange(true);
+          if (column.editable) onEditChange(true);
         }
         break;
       case "Escape":


### PR DESCRIPTION
And prevent keyboard navigation being blocked.

The guard for dblclick already exists.
```ts
function handleDoubleClick() {
    if (!column.header && !columnHeader && !rowHeader && column.editable) {
        onEditChange(true);
    }
}
```