### PR TITLE
Add a task progress indicator to notes in board view

### DIFF
--- a/src/ui/views/Board/components/Board/CardList.svelte
+++ b/src/ui/views/Board/components/Board/CardList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { InternalLink, Checkbox } from "obsidian-svelte";
+  import { InternalLink, Checkbox, Icon } from "obsidian-svelte";
   import {
     isString,
     type DataField,
@@ -19,7 +19,7 @@
     dndzone,
   } from "svelte-dnd-action";
   import { flip } from "svelte/animate";
-  import { getDisplayName } from "./boardHelpers";
+  import { getDisplayName, getTaskProgress } from "./boardHelpers";
   import type {
     DropTrigger,
     OnRecordClick,
@@ -134,13 +134,21 @@
           {/if}
         </div>
         <CardMetadata fields={includeFields} record={item} />
+        {#await getTaskProgress(item.id, $app) then taskProgress}
+        {#if taskProgress}
+        <div class=task-progress-heading>
+          <Icon name="check-circle" />
+          <span>{taskProgress}</span>
+        </div>
+        {/if}
+        {/await}
       </ColorItem>
     </article>
   {/each}
 </div>
 
 <style>
-  div.card-header {
+  div.card-header, div.task-progress-heading {
     display: flex;
     gap: 4px;
     align-items: center;

--- a/src/ui/views/Board/components/Board/boardHelpers.ts
+++ b/src/ui/views/Board/components/Board/boardHelpers.ts
@@ -1,3 +1,5 @@
+import type { App } from "obsidian";
+
 export function getDisplayName(recordId: string): string {
   const basename = getBasename(recordId);
   return basename.slice(0, basename.lastIndexOf("."));
@@ -12,4 +14,26 @@ function getBasename(str: string) {
   }
 
   return str.slice(lastSlash + 1);
+}
+
+const CHECKBOX_ITEM_REGEX = /^\s{0,3}-\s{1,4}\[.\]/;
+const COMPLETED_ITEM_REGEX = /^\s{0,3}-\s{1,4}\[\S\]/;
+
+// Look for markdown task lists in the record file content and count completion progress
+export async function getTaskProgress(recordId: string, app: App): Promise<string> {
+  let progress = "";
+
+  const file = app.vault.getFileByPath(recordId);
+  if (file) {
+    const content = await app.vault.read(file);
+    const lines = content.split("\n");
+
+    const totalTasks = lines.map(l => CHECKBOX_ITEM_REGEX.test(l)).filter(Boolean).length;
+    const completedTasks = lines.map(l => COMPLETED_ITEM_REGEX.test(l)).filter(Boolean).length;
+
+    if (totalTasks) {
+      progress = `${completedTasks}/${totalTasks}`;
+    }
+  }
+  return progress;
 }


### PR DESCRIPTION
Quick implementation of a feature I've been missing from projects - a Trello-style checkbox task progress indicator in Board view

A note with something like this:
```
- [ ] Task 1
- [x] Task 2
- [ ] Task 3
```

automatically gains this indicator:

![image](https://github.com/marcusolsson/obsidian-projects/assets/7078603/45b3a090-afb2-4843-8994-6d6d9126966d)

Let me know if this is something that will benefit projects, and if you'd like anything more fleshed out (eg, a plugin setting to enable this functionality, etc), I'd be happy to work on this further.