### PR TITLE
Enhance hover support

### DIFF
--- a/src/lib/stores/translations/en.json
+++ b/src/lib/stores/translations/en.json
@@ -482,6 +482,10 @@
                 "title": "Dataview is disabled",
                 "message": "Enable the Dataview plugin to continue using this project."
             }
+        },
+        "obsidian": {
+            "ribbon-tooltip": "Open projects",
+            "hover-link-settings": "Projects"
         }
     }
 }

--- a/src/lib/stores/translations/zh-CN.json
+++ b/src/lib/stores/translations/zh-CN.json
@@ -474,6 +474,10 @@
                 "title": "Dataview 插件未启用",
                 "message": "启用 Dataview 插件以使用本项目。"
             }
+        },
+        "obsidian": {
+            "ribbon-tooltip": "打开项目",
+            "hover-link-settings": "Projects"
         }
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,6 +65,11 @@ export default class ProjectsPlugin extends Plugin {
       (leaf) => new ProjectsView(leaf, this)
     );
 
+    this.registerHoverLinkSource(VIEW_TYPE_PROJECTS, {
+      display: "Projects Task Notes",
+      defaultMod: false
+    });
+
     // Allow the user to create a project by right-clicking a folder in the
     // File explorer.
     this.registerEvent(

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,7 +66,7 @@ export default class ProjectsPlugin extends Plugin {
     );
 
     this.registerHoverLinkSource(VIEW_TYPE_PROJECTS, {
-      defaultMod: false
+      defaultMod: true,
       display: t("obsidian.hover-link-settings"),
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ export default class ProjectsPlugin extends Plugin {
       `
     );
 
-    this.addRibbonIcon("projects-icon", "Open projects", () => {
+    this.addRibbonIcon("projects-icon", t("obsidian.ribbon-tooltip"), () => {
       this.activateView();
     });
 
@@ -66,8 +66,8 @@ export default class ProjectsPlugin extends Plugin {
     );
 
     this.registerHoverLinkSource(VIEW_TYPE_PROJECTS, {
-      display: "Projects Task Notes",
       defaultMod: false
+      display: t("obsidian.hover-link-settings"),
     });
 
     // Allow the user to create a project by right-clicking a folder in the

--- a/src/ui/components/CardMetadata/CardMetadata.svelte
+++ b/src/ui/components/CardMetadata/CardMetadata.svelte
@@ -5,6 +5,7 @@
     type DataField,
     type DataRecord,
   } from "src/lib/dataframe/dataframe";
+  import { setContext } from "svelte";
   import Checkbox from "./Checkbox.svelte";
   import Tags from "./Tags.svelte";
   import Text from "./Text.svelte";
@@ -13,6 +14,8 @@
 
   export let fields: DataField[];
   export let record: DataRecord;
+
+  setContext<string>("sourcePath", record.id);
 </script>
 
 {#each fields as field (field.name)}

--- a/src/ui/components/CardMetadata/Text.svelte
+++ b/src/ui/components/CardMetadata/Text.svelte
@@ -6,11 +6,13 @@
     Optional,
   } from "src/lib/dataframe/dataframe";
   import { app, view } from "src/lib/stores/obsidian";
+  import { handleHoverLink } from "src/ui/views/helpers";
+  import { getContext } from "svelte";
 
   export let value: Optional<DataValue>;
   export let field: DataField;
 
-  export let sourcePath: string = "";
+  const sourcePath = getContext<string>("sourcePath") ?? "";
 
   function useMarkdown(node: HTMLElement) {
     if (typeof value === "string") {
@@ -43,7 +45,13 @@
 </script>
 
 {#if field.typeConfig?.richText}
-  <div use:useMarkdown on:click={handleClick} on:keypress />
+  <div
+    use:useMarkdown
+    on:click={handleClick}
+    on:mouseover={(event) => handleHoverLink(event, sourcePath)}
+    on:focus
+    on:keypress
+  />
 {:else if typeof value === "string"}
   <div>
     {value}

--- a/src/ui/components/InternalLink.svelte
+++ b/src/ui/components/InternalLink.svelte
@@ -17,21 +17,13 @@
    */
   export let resolved;
 
-  interface openLink {
-    linkText: string;
-    sourcePath: string;
-    newLeaf: boolean;
-  }
-
-  interface hoverLink {
-    event: MouseEvent;
-    linkText: string;
-    sourcePath: string;
-  }
-
   const dispatch = createEventDispatcher<{
-    open: openLink;
-    hover: hoverLink;
+    open: { linkText: string; sourcePath: string; newLeaf: boolean };
+    hover: {
+      event: MouseEvent;
+      linkText: string;
+      sourcePath: string;
+    };
   }>();
   let aria = {};
   if (tooltip) {

--- a/src/ui/components/InternalLink.svelte
+++ b/src/ui/components/InternalLink.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  /**
+   * Specifies the link text.
+   */
+  export let linkText: string;
+  /**
+   * Specifies the path to the source file.
+   */
+  export let sourcePath: string;
+  /**
+   * Specifies a tooltip to display when hovering the link.
+   */
+  export let tooltip = "";
+  /**
+   * Specifies whether the link is resolved.
+   */
+  export let resolved;
+
+  interface openLink {
+    linkText: string;
+    sourcePath: string;
+    newLeaf: boolean;
+  }
+
+  interface hoverLink {
+    event: MouseEvent;
+    linkText: string;
+    sourcePath: string;
+  }
+
+  const dispatch = createEventDispatcher<{
+    open: openLink;
+    hover: hoverLink;
+  }>();
+  let aria = {};
+  if (tooltip) {
+    aria = {
+      "aria-label": tooltip,
+      "aria-label-position": "top",
+    };
+  }
+</script>
+
+<a
+  href={linkText}
+  data-href={linkText}
+  class={`internal-link`}
+  class:is-unresolved={!resolved}
+  target="_blank"
+  rel="noopener"
+  on:click={(event) => {
+    event.stopPropagation();
+
+    dispatch("open", {
+      linkText,
+      sourcePath,
+      newLeaf: event.ctrlKey || event.metaKey,
+    });
+  }}
+  on:mouseover={(event) => {
+    event.stopPropagation();
+
+    dispatch("hover", {
+      event,
+      linkText,
+      sourcePath,
+    });
+  }}
+  on:focus
+  {...aria}
+>
+  <slot />
+</a>
+
+<style>
+  .is-unresolved {
+    opacity: 0.5;
+  }
+</style>

--- a/src/ui/components/InternalLink.svelte
+++ b/src/ui/components/InternalLink.svelte
@@ -43,6 +43,7 @@
   rel="noopener"
   on:click={(event) => {
     event.stopPropagation();
+    event.preventDefault();
 
     dispatch("open", {
       linkText,
@@ -52,6 +53,7 @@
   }}
   on:mouseover={(event) => {
     event.stopPropagation();
+    event.preventDefault();
 
     dispatch("hover", {
       event,

--- a/src/ui/views/Board/components/Board/CardList.svelte
+++ b/src/ui/views/Board/components/Board/CardList.svelte
@@ -11,6 +11,7 @@
   import ColorItem from "src/ui/components/ColorItem/ColorItem.svelte";
   import {
     getRecordColorContext,
+    handleHoverLink,
     sortRecordsContext,
   } from "src/ui/views/helpers";
   import {
@@ -26,8 +27,6 @@
     OnRecordCheck,
     OnRecordDrop,
   } from "./types";
-  import { TFile } from "obsidian";
-  import { VIEW_TYPE_PROJECTS } from "src/view";
 
   export let items: DataRecord[];
   export let onRecordClick: OnRecordClick;
@@ -66,27 +65,6 @@
 
   const isPlaceholder = (item: DataRecord) =>
     !!(item as any)[SHADOW_ITEM_MARKER_PROPERTY_NAME];
-
-  function handleHoverLink(event: MouseEvent) {
-    const targetEl = event.target as HTMLDivElement;
-    const anchor =
-      targetEl.tagName === "A" ? targetEl : targetEl.querySelector("a");
-    if (!anchor || !anchor.hasClass("internal-link")) return;
-
-    const href = anchor.getAttr("href");
-    const file = href && $app.metadataCache.getFirstLinkpathDest(href, "");
-
-    if (file instanceof TFile) {
-      $app.workspace.trigger("hover-link", {
-        event,
-        source: VIEW_TYPE_PROJECTS,
-        hoverParent: anchor,
-        targetEl,
-        linktext: file.name,
-        sourcePath: file.path,
-      });
-    }
-  }
 </script>
 
 <div
@@ -131,7 +109,7 @@
           {/if}
           {#if !customHeader}
             <!-- svelte-ignore a11y-mouse-events-have-key-events -->
-            <span class="link-wrapper" on:mouseover={handleHoverLink}>
+            <span class="link-wrapper" on:mouseover={((event) => {handleHoverLink(event, "");})}>
             <InternalLink
               linkText={item.id}
               sourcePath=""

--- a/src/ui/views/Board/components/Board/CardList.svelte
+++ b/src/ui/views/Board/components/Board/CardList.svelte
@@ -26,6 +26,8 @@
     OnRecordCheck,
     OnRecordDrop,
   } from "./types";
+  import { TFile } from "obsidian";
+  import { VIEW_TYPE_PROJECTS } from "src/view";
 
   export let items: DataRecord[];
   export let onRecordClick: OnRecordClick;
@@ -64,6 +66,27 @@
 
   const isPlaceholder = (item: DataRecord) =>
     !!(item as any)[SHADOW_ITEM_MARKER_PROPERTY_NAME];
+
+  function handleHoverLink(event: MouseEvent) {
+    const targetEl = event.target as HTMLDivElement;
+    const anchor =
+      targetEl.tagName === "A" ? targetEl : targetEl.querySelector("a");
+    if (!anchor || !anchor.hasClass("internal-link")) return;
+
+    const href = anchor.getAttr("href");
+    const file = href && $app.metadataCache.getFirstLinkpathDest(href, "");
+
+    if (file instanceof TFile) {
+      $app.workspace.trigger("hover-link", {
+        event,
+        source: VIEW_TYPE_PROJECTS,
+        hoverParent: anchor,
+        targetEl,
+        linktext: file.name,
+        sourcePath: file.path,
+      });
+    }
+  }
 </script>
 
 <div
@@ -107,6 +130,8 @@
             </span>
           {/if}
           {#if !customHeader}
+            <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+            <span class="link-wrapper" on:mouseover={handleHoverLink}>
             <InternalLink
               linkText={item.id}
               sourcePath=""
@@ -129,6 +154,7 @@
               {@const path = item.values["path"]}
               {getDisplayName(isString(path) ? path : item.id)}
             </InternalLink>
+            </span>
           {:else}
             <CardMetadata fields={[customHeader]} record={item} />
           {/if}

--- a/src/ui/views/Board/components/Board/CardList.svelte
+++ b/src/ui/views/Board/components/Board/CardList.svelte
@@ -109,29 +109,34 @@
           {/if}
           {#if !customHeader}
             <!-- svelte-ignore a11y-mouse-events-have-key-events -->
-            <span class="link-wrapper" on:mouseover={((event) => {handleHoverLink(event, "");})}>
-            <InternalLink
-              linkText={item.id}
-              sourcePath=""
-              resolved
-              on:open={({ detail: { linkText, sourcePath, newLeaf } }) => {
-                let openEditor =
-                  $settings.preferences.linkBehavior == "open-editor";
-
-                if (newLeaf) {
-                  openEditor = !openEditor;
-                }
-
-                if (openEditor) {
-                  onRecordClick(item);
-                } else {
-                  $app.workspace.openLinkText(linkText, sourcePath, true);
-                }
+            <span
+              class="link-wrapper"
+              on:mouseover={(event) => {
+                handleHoverLink(event, "");
               }}
             >
-              {@const path = item.values["path"]}
-              {getDisplayName(isString(path) ? path : item.id)}
-            </InternalLink>
+              <InternalLink
+                linkText={item.id}
+                sourcePath=""
+                resolved
+                on:open={({ detail: { linkText, sourcePath, newLeaf } }) => {
+                  let openEditor =
+                    $settings.preferences.linkBehavior == "open-editor";
+
+                  if (newLeaf) {
+                    openEditor = !openEditor;
+                  }
+
+                  if (openEditor) {
+                    onRecordClick(item);
+                  } else {
+                    $app.workspace.openLinkText(linkText, sourcePath, true);
+                  }
+                }}
+              >
+                {@const path = item.values["path"]}
+                {getDisplayName(isString(path) ? path : item.id)}
+              </InternalLink>
             </span>
           {:else}
             <CardMetadata fields={[customHeader]} record={item} />

--- a/src/ui/views/Board/components/Board/CardList.svelte
+++ b/src/ui/views/Board/components/Board/CardList.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import { InternalLink, Checkbox } from "obsidian-svelte";
+  // import { Checkbox, InternalLink} from "obsidian-svelte";
+  import { Checkbox } from "obsidian-svelte";
+  import InternalLink from "src/ui/components/InternalLink.svelte";
+
   import {
     isString,
     type DataField,
@@ -108,36 +111,31 @@
             </span>
           {/if}
           {#if !customHeader}
-            <!-- svelte-ignore a11y-mouse-events-have-key-events -->
-            <span
-              class="link-wrapper"
-              on:mouseover={(event) => {
-                handleHoverLink(event, "");
+            <InternalLink
+              linkText={item.id}
+              sourcePath=""
+              resolved
+              on:open={({ detail: { linkText, sourcePath, newLeaf } }) => {
+                let openEditor =
+                  $settings.preferences.linkBehavior == "open-editor";
+
+                if (newLeaf) {
+                  openEditor = !openEditor;
+                }
+
+                if (openEditor) {
+                  onRecordClick(item);
+                } else {
+                  $app.workspace.openLinkText(linkText, sourcePath, true);
+                }
+              }}
+              on:hover={({ detail: { event, sourcePath } }) => {
+                handleHoverLink(event, sourcePath);
               }}
             >
-              <InternalLink
-                linkText={item.id}
-                sourcePath=""
-                resolved
-                on:open={({ detail: { linkText, sourcePath, newLeaf } }) => {
-                  let openEditor =
-                    $settings.preferences.linkBehavior == "open-editor";
-
-                  if (newLeaf) {
-                    openEditor = !openEditor;
-                  }
-
-                  if (openEditor) {
-                    onRecordClick(item);
-                  } else {
-                    $app.workspace.openLinkText(linkText, sourcePath, true);
-                  }
-                }}
-              >
-                {@const path = item.values["path"]}
-                {getDisplayName(isString(path) ? path : item.id)}
-              </InternalLink>
-            </span>
+              {@const path = item.values["path"]}
+              {getDisplayName(isString(path) ? path : item.id)}
+            </InternalLink>
           {:else}
             <CardMetadata fields={[customHeader]} record={item} />
           {/if}

--- a/src/ui/views/Board/components/Board/CardList.svelte
+++ b/src/ui/views/Board/components/Board/CardList.svelte
@@ -113,7 +113,7 @@
           {#if !customHeader}
             <InternalLink
               linkText={item.id}
-              sourcePath=""
+              sourcePath={item.id}
               resolved
               on:open={({ detail: { linkText, sourcePath, newLeaf } }) => {
                 let openEditor =

--- a/src/ui/views/Board/components/Board/ColumnHeader.svelte
+++ b/src/ui/views/Board/components/Board/ColumnHeader.svelte
@@ -4,6 +4,7 @@
   import { getContext } from "svelte";
   import { TextInput, IconButton } from "obsidian-svelte";
   import { Flair } from "src/ui/components/Flair";
+  import { handleHoverLink } from "src/ui/views/helpers";
 
   export let value: string;
   export let count: number;
@@ -114,6 +115,8 @@
     <span
       class:collapse
       use:useMarkdown={value}
+      on:mouseover={(event) => handleHoverLink(event, "")}
+      on:focus
       on:click={handleClick}
       on:keypress
     />

--- a/src/ui/views/Calendar/components/Calendar/EventList.svelte
+++ b/src/ui/views/Calendar/components/Calendar/EventList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { InternalLink } from "obsidian-svelte";
+  // import { InternalLink } from "obsidian-svelte";
+  import InternalLink from "src/ui/components/InternalLink.svelte";
   import { getDisplayName } from "src/ui/views/Board/components/Board/boardHelpers";
   import Event from "./Event.svelte";
   import { dndzone } from "svelte-dnd-action";
@@ -10,7 +11,7 @@
     Optional,
   } from "src/lib/dataframe/dataframe";
   import { updateRecordValues } from "src/lib/datasources/helpers";
-  import { getRecordColorContext } from "src/ui/views/helpers";
+  import { getRecordColorContext, handleHoverLink } from "src/ui/views/helpers";
   import { settings } from "src/lib/stores/settings";
 
   export let records: DataRecord[];
@@ -76,7 +77,7 @@
       >
         <InternalLink
           linkText={record.id}
-          sourcePath=""
+          sourcePath={record.id}
           resolved
           tooltip={getDisplayName(record.id)}
           on:open={({ detail: { linkText, sourcePath, newLeaf } }) => {
@@ -92,6 +93,9 @@
             } else {
               $app.workspace.openLinkText(linkText, sourcePath, true);
             }
+          }}
+          on:hover={({ detail: { event, sourcePath } }) => {
+            handleHoverLink(event, sourcePath);
           }}
         >
           {getDisplayName(record.id)}

--- a/src/ui/views/Gallery/GalleryView.svelte
+++ b/src/ui/views/Gallery/GalleryView.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import { Icon, IconButton, InternalLink, Typography } from "obsidian-svelte";
+  // import { Icon, IconButton, InternalLink, Typography } from "obsidian-svelte";
+  import { Icon, IconButton, Typography } from "obsidian-svelte";
+  import InternalLink from "src/ui/components/InternalLink.svelte";
   import CardMetadata from "src/ui/components/CardMetadata/CardMetadata.svelte";
   import ColorItem from "src/ui/components/ColorItem/ColorItem.svelte";
 
@@ -22,6 +24,7 @@
   import GalleryOptionsProvider from "./GalleryOptionsProvider.svelte";
   import { getCoverRealPath } from "./gallery";
   import { settings } from "src/lib/stores/settings";
+  import { handleHoverLink } from "../helpers";
 
   export let project: ProjectDefinition;
   export let frame: DataFrame;
@@ -96,7 +99,7 @@
               <InternalLink
                 slot="header"
                 linkText={record.id}
-                sourcePath=""
+                sourcePath={record.id}
                 resolved
                 on:open={({ detail: { linkText, sourcePath, newLeaf } }) => {
                   let openEditor =
@@ -111,6 +114,9 @@
                   } else {
                     $app.workspace.openLinkText(linkText, sourcePath, true);
                   }
+                }}
+                on:hover={({ detail: { event, sourcePath } }) => {
+                  handleHoverLink(event, sourcePath);
                 }}
               >
                 {getDisplayName(record.id)}

--- a/src/ui/views/Table/components/DataGrid/GridCell/GridListCell/RichTextTag.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridCell/GridListCell/RichTextTag.svelte
@@ -5,6 +5,7 @@
   const sourcePath = getContext<string>("sourcePath") ?? "";
 
   import { app } from "src/lib/stores/obsidian";
+  import { handleHoverLink } from "src/ui/views/helpers";
 
   export let value: string;
   export let richText: boolean = false;
@@ -43,7 +44,15 @@
 </script>
 
 {#if richText}
-  <div use:useMarkdown={value} on:click={handleClick} on:keypress />
+  <div
+    use:useMarkdown={value}
+    on:click={handleClick}
+    on:mouseover={(event) => {
+      handleHoverLink(event, sourcePath);
+    }}
+    on:focus
+    on:keypress
+  />
 {:else}
   <div>{value}</div>
 {/if}

--- a/src/ui/views/Table/components/DataGrid/GridCell/GridTextCell/TextLabel.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridCell/GridTextCell/TextLabel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { MarkdownRenderer } from "obsidian";
   import { app, view } from "src/lib/stores/obsidian";
+  import { handleHoverLink } from "src/ui/views/helpers";
   import { getContext } from "svelte";
 
   export let value: string;
@@ -42,7 +43,15 @@
 </script>
 
 {#if richText}
-  <div use:useMarkdown={value} on:click={handleClick} on:keypress />
+  <div
+    use:useMarkdown={value}
+    on:click={handleClick}
+    on:mouseover={(event) => {
+      handleHoverLink(event, sourcePath);
+    }}
+    on:focus
+    on:keypress
+  />
 {:else}
   <div>
     {value}

--- a/src/ui/views/Table/components/DataGrid/GridCellGroup.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridCellGroup.svelte
@@ -4,14 +4,7 @@
   export let footer: boolean = false;
 </script>
 
-<div
-  role="row"
-  aria-rowindex={index}
-  class:header
-  class:footer
-  on:mouseover
-  on:focus
->
+<div role="row" aria-rowindex={index} class:header class:footer>
   <slot />
 </div>
 

--- a/src/ui/views/Table/components/DataGrid/GridRow.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridRow.svelte
@@ -11,6 +11,7 @@
   import { app } from "src/lib/stores/obsidian";
 
   import { setContext } from "svelte";
+  import { VIEW_TYPE_PROJECTS } from "src/view";
 
   export let rowId: GridRowId;
   export let index: number;
@@ -56,10 +57,6 @@
   }
 
   function handleHoverLink(event: MouseEvent) {
-    if (!event.ctrlKey && !event.metaKey) {
-      return;
-    }
-
     const targetEl = event.target as HTMLDivElement;
     const anchor =
       targetEl.tagName === "A" ? targetEl : targetEl.querySelector("a");
@@ -71,7 +68,7 @@
     if (file instanceof TFile) {
       $app.workspace.trigger("hover-link", {
         event,
-        source: "obsidian-projects-table-view",
+        source: VIEW_TYPE_PROJECTS,
         hoverParent: anchor,
         targetEl,
         linktext: file.name,

--- a/src/ui/views/Table/components/DataGrid/GridRow.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridRow.svelte
@@ -1,17 +1,15 @@
 <script lang="ts">
   import produce from "immer";
-  import { TFile, type Menu } from "obsidian";
+  import type { Menu } from "obsidian";
 
   import { GridCell, GridTypedCell } from "./GridCell";
   import type { DataValue, Optional } from "src/lib/dataframe/dataframe";
   import GridCellGroup from "./GridCellGroup.svelte";
 
   import type { GridColDef, GridRowId, GridRowModel } from "./dataGrid";
-  import { menuOnContextMenu } from "src/ui/views/helpers";
-  import { app } from "src/lib/stores/obsidian";
+  import { handleHoverLink, menuOnContextMenu } from "src/ui/views/helpers";
 
   import { setContext } from "svelte";
-  import { VIEW_TYPE_PROJECTS } from "src/view";
 
   export let rowId: GridRowId;
   export let index: number;
@@ -55,30 +53,9 @@
       }
     };
   }
-
-  function handleHoverLink(event: MouseEvent) {
-    const targetEl = event.target as HTMLDivElement;
-    const anchor =
-      targetEl.tagName === "A" ? targetEl : targetEl.querySelector("a");
-    if (!anchor || !anchor.hasClass("internal-link")) return;
-
-    const href = anchor.getAttr("href");
-    const file = href && $app.metadataCache.getFirstLinkpathDest(href, rowId);
-
-    if (file instanceof TFile) {
-      $app.workspace.trigger("hover-link", {
-        event,
-        source: VIEW_TYPE_PROJECTS,
-        hoverParent: anchor,
-        targetEl,
-        linktext: file.name,
-        sourcePath: file.path,
-      });
-    }
-  }
 </script>
 
-<GridCellGroup on:mouseover={handleHoverLink} {index}>
+<GridCellGroup on:mouseover={((event) => {handleHoverLink(event, rowId);})} {index}>
   <GridCell
     rowindex={1}
     colindex={1}

--- a/src/ui/views/Table/components/DataGrid/GridRow.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridRow.svelte
@@ -55,7 +55,12 @@
   }
 </script>
 
-<GridCellGroup on:mouseover={((event) => {handleHoverLink(event, rowId);})} {index}>
+<GridCellGroup
+  on:mouseover={(event) => {
+    handleHoverLink(event, rowId);
+  }}
+  {index}
+>
   <GridCell
     rowindex={1}
     colindex={1}

--- a/src/ui/views/Table/components/DataGrid/GridRow.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridRow.svelte
@@ -7,7 +7,7 @@
   import GridCellGroup from "./GridCellGroup.svelte";
 
   import type { GridColDef, GridRowId, GridRowModel } from "./dataGrid";
-  import { handleHoverLink, menuOnContextMenu } from "src/ui/views/helpers";
+  import { menuOnContextMenu } from "src/ui/views/helpers";
 
   import { setContext } from "svelte";
 
@@ -55,12 +55,7 @@
   }
 </script>
 
-<GridCellGroup
-  on:mouseover={(event) => {
-    handleHoverLink(event, rowId);
-  }}
-  {index}
->
+<GridCellGroup {index}>
   <GridCell
     rowindex={1}
     colindex={1}

--- a/src/ui/views/helpers.ts
+++ b/src/ui/views/helpers.ts
@@ -1,10 +1,12 @@
 import { makeContext } from "src/lib/helpers";
 import { DataFieldType, type DataField } from "../../lib/dataframe/dataframe";
 import type { ViewProps } from "../app/useView";
-import type { Menu } from "obsidian";
+import { TFile, type Menu } from "obsidian";
 
 import { i18n } from "src/lib/stores/i18n";
+import { app } from "src/lib/stores/obsidian";
 import { get } from "svelte/store";
+import { VIEW_TYPE_PROJECTS } from "src/view";
 
 export function fieldIcon(field: DataField): string {
   switch (field.type) {
@@ -74,3 +76,24 @@ export function menuOnContextMenu(event: MouseEvent, menu: Menu): void {
   };
   window.addEventListener("contextmenu", contextMenuFunc, false);
 }
+
+export function handleHoverLink(event: MouseEvent, sourcePath: string) {
+    const targetEl = event.target as HTMLDivElement;
+    const anchor =
+      targetEl.tagName === "A" ? targetEl : targetEl.querySelector("a");
+    if (!anchor || !anchor.hasClass("internal-link")) return;
+
+    const href = anchor.getAttr("href");
+    const file = href && get(app).metadataCache.getFirstLinkpathDest(href, sourcePath);
+
+    if (file instanceof TFile) {
+      get(app).workspace.trigger("hover-link", {
+        event,
+        source: VIEW_TYPE_PROJECTS,
+        hoverParent: anchor,
+        targetEl,
+        linktext: file.name,
+        sourcePath: file.path,
+      });
+    }
+  }

--- a/src/ui/views/helpers.ts
+++ b/src/ui/views/helpers.ts
@@ -78,22 +78,23 @@ export function menuOnContextMenu(event: MouseEvent, menu: Menu): void {
 }
 
 export function handleHoverLink(event: MouseEvent, sourcePath: string) {
-    const targetEl = event.target as HTMLDivElement;
-    const anchor =
-      targetEl.tagName === "A" ? targetEl : targetEl.querySelector("a");
-    if (!anchor || !anchor.hasClass("internal-link")) return;
+  const targetEl = event.target as HTMLDivElement;
+  const anchor =
+    targetEl.tagName === "A" ? targetEl : targetEl.querySelector("a");
+  if (!anchor || !anchor.hasClass("internal-link")) return;
 
-    const href = anchor.getAttr("href");
-    const file = href && get(app).metadataCache.getFirstLinkpathDest(href, sourcePath);
+  const href = anchor.getAttr("href");
+  const file =
+    href && get(app).metadataCache.getFirstLinkpathDest(href, sourcePath);
 
-    if (file instanceof TFile) {
-      get(app).workspace.trigger("hover-link", {
-        event,
-        source: VIEW_TYPE_PROJECTS,
-        hoverParent: anchor,
-        targetEl,
-        linktext: file.name,
-        sourcePath: file.path,
-      });
-    }
+  if (file instanceof TFile) {
+    get(app).workspace.trigger("hover-link", {
+      event,
+      source: VIEW_TYPE_PROJECTS,
+      hoverParent: anchor,
+      targetEl,
+      linktext: file.name,
+      sourcePath: file.path,
+    });
   }
+}


### PR DESCRIPTION
A quick little adjustment I was missing: using hover preview to quickly go through notes in Board view.

I also took the opportunity adjust the hover treatment of Table view to a more preferred setup: instead of handling the meta keys in projects, we should register a new hover view source, that way the meta key treatment can be toggled inside Page Preview settings:

![image](https://github.com/marcusolsson/obsidian-projects/assets/7078603/799a9643-88bc-4ee4-b390-4b64bf7aea37)

Tested and made sure this works with both core Page Preview and the Hover Editor plugin.