### PR TITLE
Fix changing view on Android devides

### DIFF
--- a/src/ui/app/toolbar/ViewItem.svelte
+++ b/src/ui/app/toolbar/ViewItem.svelte
@@ -64,7 +64,8 @@
   class:active
   class:error
   on:dblclick={() => (editing = true)}
-  on:mousedown
+  on:click
+  on:keydown
 >
   {#if icon}
     <Icon name={icon} />

--- a/src/ui/app/toolbar/ViewSelect.svelte
+++ b/src/ui/app/toolbar/ViewSelect.svelte
@@ -70,7 +70,7 @@
             active={viewId === v.id}
             label={v.name}
             icon={iconFromViewType(v.type)}
-            on:mousedown={() => onViewChange(v.id)}
+            on:click={() => onViewChange(v.id)}
             on:rename={({ detail: name }) => {
               onViewRename(v.id, name);
             }}


### PR DESCRIPTION
Closes #858, closes #894, closes #903

It seems that the `on:mousedown` event won't trigger on android devices. While iOS supports treating `on:mousedown` as `on:touchstart`. Weird though.