### PR TITLE
Handle cleared date-input value

### DIFF
--- a/src/ui/components/FieldControl/FieldControl.svelte
+++ b/src/ui/components/FieldControl/FieldControl.svelte
@@ -25,7 +25,7 @@
 
   export let field: DataField;
   export let value: Optional<DataValue>;
-  let cachedValue: Optional<Date>;
+  let cachedValue: Optional<Date>; // store the proposing value
   export let onChange: (value: Optional<DataValue>) => void;
   export let readonly: boolean = false;
 

--- a/src/ui/components/FieldControl/FieldControl.svelte
+++ b/src/ui/components/FieldControl/FieldControl.svelte
@@ -75,6 +75,10 @@
       value={isDate(value) ? value : null}
       on:change={({ detail: value }) => (cachedValue = value)}
       on:blur={() => {
+        if (!cachedValue) {
+          onChange(cachedValue);
+          return;
+        }
         const cachedDate = dayjs(cachedValue);
         const newDatetime = dayjs(isDate(value) ? value : null)
           .set("year", cachedDate.year())

--- a/src/ui/modals/components/CreateField.svelte
+++ b/src/ui/modals/components/CreateField.svelte
@@ -333,7 +333,8 @@
         } else if (field.type === DataFieldType.Date) {
           onCreate(
             field,
-            dayjs(dateValue).format(
+            // If no date(time) value specified still add today's date / current time
+            dayjs(dateValue ?? "").format(
               field.typeConfig?.time ? "YYYY-MM-DDTHH:mm" : "YYYY-MM-DD"
             )
           );

--- a/src/ui/views/Table/components/DataGrid/GridCell/GridDateCell/GridDateCell.svelte
+++ b/src/ui/views/Table/components/DataGrid/GridCell/GridDateCell/GridDateCell.svelte
@@ -8,7 +8,7 @@
   import type { GridColDef } from "../../dataGrid";
 
   export let value: Optional<Date>;
-  let cachedValue: Optional<Date>;
+  let cachedValue: Optional<Date>; // store the proposing value
   export let onChange: (value: Optional<Date>) => void;
   export let column: GridColDef;
   export let rowindex: number;
@@ -58,6 +58,10 @@
       on:change={({ detail: value }) => (cachedValue = value)}
       on:blur={() => {
         edit = false;
+        if (!cachedValue) {
+          onChange(cachedValue);
+          return;
+        }
         const cachedDate = dayjs(cachedValue);
         const newDatetime = dayjs(value)
           .set("year", cachedDate.year())


### PR DESCRIPTION
Follows-up #892 

Click `clear` in date-picker with value now won't yield a string `Invalid date` but write `null` back. Credits to @GitMurf for reporting!