### PR TITLE
Added a filter option to search for parts of entries contained in lists

### DIFF
--- a/src/settings/base/settings.ts
+++ b/src/settings/base/settings.ts
@@ -146,6 +146,12 @@ export const filterOperatorTypes: Record<FilterOperator, FilterOperatorType> = {
   "has-keyword": "binary-text",
 };
 
+export function getFilterOperatorType(
+  op: FilterOperator | undefined
+): FilterOperatorType | undefined {
+  return op ? filterOperatorTypes[op] : undefined;
+}
+
 export interface FilterCondition {
   readonly field: string;
   readonly operator: FilterOperator;

--- a/src/settings/base/settings.ts
+++ b/src/settings/base/settings.ts
@@ -90,12 +90,12 @@ export function isDateFilterOperator(
   ].includes(op);
 }
 
-export type ListFilterOperator = "has-any-of" | "has-all-of" | "has-none-of";
+export type ListFilterOperator = "has-any-of" | "has-all-of" | "has-none-of" | "contains-part-of";
 
 export function isListFilterOperator(
   op: FilterOperator
 ): op is ListFilterOperator {
-  return ["has-any-of", "has-all-of", "has-none-of"].includes(op);
+  return ["has-any-of", "has-all-of", "has-none-of", "contains-part-of"].includes(op);
 }
 
 export type FilterOperator =
@@ -132,6 +132,7 @@ export const filterOperatorTypes: Record<FilterOperator, FilterOperatorType> = {
   "has-any-of": "binary",
   "has-all-of": "binary",
   "has-none-of": "binary",
+  "contains-part-of": "binary",
 };
 
 export interface FilterCondition {

--- a/src/settings/base/settings.ts
+++ b/src/settings/base/settings.ts
@@ -90,12 +90,12 @@ export function isDateFilterOperator(
   ].includes(op);
 }
 
-export type ListFilterOperator = "has-any-of" | "has-all-of" | "has-none-of" | "contains-part-of";
+export type ListFilterOperator = "has-any-of" | "has-all-of" | "has-none-of" | "has-keyword";
 
 export function isListFilterOperator(
   op: FilterOperator
 ): op is ListFilterOperator {
-  return ["has-any-of", "has-all-of", "has-none-of", "contains-part-of"].includes(op);
+  return ["has-any-of", "has-all-of", "has-none-of", "has-keyword"].includes(op);
 }
 
 export type FilterOperator =
@@ -132,7 +132,7 @@ export const filterOperatorTypes: Record<FilterOperator, FilterOperatorType> = {
   "has-any-of": "binary",
   "has-all-of": "binary",
   "has-none-of": "binary",
-  "contains-part-of": "binary",
+  "has-keyword": "binary",
 };
 
 export interface FilterCondition {

--- a/src/settings/base/settings.ts
+++ b/src/settings/base/settings.ts
@@ -90,12 +90,18 @@ export function isDateFilterOperator(
   ].includes(op);
 }
 
-export type ListFilterOperator = "has-any-of" | "has-all-of" | "has-none-of" | "has-keyword";
+export type ListFilterOperator =
+  | "has-any-of"
+  | "has-all-of"
+  | "has-none-of"
+  | "has-keyword";
 
 export function isListFilterOperator(
   op: FilterOperator
 ): op is ListFilterOperator {
-  return ["has-any-of", "has-all-of", "has-none-of", "has-keyword"].includes(op);
+  return ["has-any-of", "has-all-of", "has-none-of", "has-keyword"].includes(
+    op
+  );
 }
 
 export type FilterOperator =
@@ -106,33 +112,38 @@ export type FilterOperator =
   | DateFilterOperator
   | ListFilterOperator;
 
-export type FilterOperatorType = "unary" | "binary";
+export type FilterOperatorType =
+  | "unary"
+  | "binary-text"
+  | "binary-number"
+  | "binary-date"
+  | "binary-multitext";
 
 export const filterOperatorTypes: Record<FilterOperator, FilterOperatorType> = {
   "is-empty": "unary",
   "is-not-empty": "unary",
-  is: "binary",
-  "is-not": "binary",
-  contains: "binary",
-  "not-contains": "binary",
-  eq: "binary",
-  neq: "binary",
-  lt: "binary",
-  gt: "binary",
-  lte: "binary",
-  gte: "binary",
+  is: "binary-text",
+  "is-not": "binary-text",
+  contains: "binary-text",
+  "not-contains": "binary-text",
+  eq: "binary-number",
+  neq: "binary-number",
+  lt: "binary-number",
+  gt: "binary-number",
+  lte: "binary-number",
+  gte: "binary-number",
   "is-checked": "unary",
   "is-not-checked": "unary",
-  "is-on": "binary",
-  "is-not-on": "binary",
-  "is-before": "binary",
-  "is-after": "binary",
-  "is-on-and-before": "binary",
-  "is-on-and-after": "binary",
-  "has-any-of": "binary",
-  "has-all-of": "binary",
-  "has-none-of": "binary",
-  "has-keyword": "binary",
+  "is-on": "binary-date",
+  "is-not-on": "binary-date",
+  "is-before": "binary-date",
+  "is-after": "binary-date",
+  "is-on-and-before": "binary-date",
+  "is-on-and-after": "binary-date",
+  "has-any-of": "binary-multitext",
+  "has-all-of": "binary-multitext",
+  "has-none-of": "binary-multitext",
+  "has-keyword": "binary-text",
 };
 
 export interface FilterCondition {

--- a/src/ui/app/filterFunctions.ts
+++ b/src/ui/app/filterFunctions.ts
@@ -167,6 +167,10 @@ export const listFns: Record<
     return !(right ? right.some((value) => left.includes(value)) : false);
   },
   "has-keyword": (left, right) => {
-    return right ? right.some((value) => left.some((l) => l.includes(value))) : false;
+    return right ? right.some(rightValue => 
+        left.some(leftValue => 
+          String(leftValue).includes(String(rightValue))
+        )
+      ) : false;
   },
 };

--- a/src/ui/app/filterFunctions.ts
+++ b/src/ui/app/filterFunctions.ts
@@ -166,7 +166,7 @@ export const listFns: Record<
   "has-none-of": (left, right) => {
     return !(right ? right.some((value) => left.includes(value)) : false);
   },
-  "contains-part-of": (left, right) => {
+  "has-keyword": (left, right) => {
     return right ? right.some((value) => left.some((l) => l.includes(value))) : false;
   },
 };

--- a/src/ui/app/filterFunctions.ts
+++ b/src/ui/app/filterFunctions.ts
@@ -159,7 +159,6 @@ export const listFns: Record<
 > = {
   "has-any-of": (left, right) => {
     return right ? right.some((value) => left.includes(value)) : false;
-    // return right ? right.some((value) => left.some((l) => l.includes(value))) : false;
   },
   "has-all-of": (left, right) => {
     return right ? right.every((value) => left.includes(value)) : false;

--- a/src/ui/app/filterFunctions.ts
+++ b/src/ui/app/filterFunctions.ts
@@ -159,11 +159,15 @@ export const listFns: Record<
 > = {
   "has-any-of": (left, right) => {
     return right ? right.some((value) => left.includes(value)) : false;
+    // return right ? right.some((value) => left.some((l) => l.includes(value))) : false;
   },
   "has-all-of": (left, right) => {
     return right ? right.every((value) => left.includes(value)) : false;
   },
   "has-none-of": (left, right) => {
     return !(right ? right.some((value) => left.includes(value)) : false);
+  },
+  "contains-part-of": (left, right) => {
+    return right ? right.some((value) => left.some((l) => l.includes(value))) : false;
   },
 };

--- a/src/ui/app/filterFunctions.ts
+++ b/src/ui/app/filterFunctions.ts
@@ -40,11 +40,13 @@ export function matchesCondition(
     return baseFns[operator](value);
   }
 
-  if (isOptionalList(value)) {
-    if (isListFilterOperator(operator)) {
+  if (isOptionalList(value) && isListFilterOperator(operator)) {
+    if (operator === "has-keyword") {
+      return listFns[operator](value ?? [], cond.value);
+    } else {
       return listFns[operator](
         value ?? [],
-        cond.value ? JSON.parse(cond.value ?? "[]") : undefined
+        cond.value ? JSON.parse(cond.value) : undefined
       );
     }
   }
@@ -61,7 +63,7 @@ export function matchesCondition(
   } else if (isOptionalDate(value) && isDateFilterOperator(operator)) {
     return dateFns[operator](
       value,
-      cond.value ? dayjs(cond.value ?? "").toDate() : undefined
+      cond.value ? dayjs(cond.value).toDate() : undefined
     );
   }
 
@@ -153,8 +155,8 @@ export const dateFns: Record<
     left && right ? left.getTime() >= right.getTime() : false,
 };
 
-export const listFns: Record<
-  ListFilterOperator,
+export const listFns_multitext: Record<
+  Exclude<ListFilterOperator, "has-keyword">,
   (left: Optional<DataValue>[], right?: Optional<DataValue>[]) => boolean
 > = {
   "has-any-of": (left, right) => {
@@ -166,11 +168,20 @@ export const listFns: Record<
   "has-none-of": (left, right) => {
     return !(right ? right.some((value) => left.includes(value)) : false);
   },
+};
+
+export const listFns_text: Record<
+  "has-keyword",
+  (left: Optional<DataValue>[], right?: string) => boolean
+> = {
   "has-keyword": (left, right) => {
-    return right ? right.some(rightValue => 
-        left.some(leftValue => 
-          String(leftValue).includes(String(rightValue))
-        )
-      ) : false;
+    return right
+      ? left.some((value) => String(value).contains(String(right)))
+      : false;
   },
+};
+
+export const listFns = {
+  ...listFns_multitext,
+  ...listFns_text,
 };

--- a/src/ui/app/toolbar/viewOptions/color/helpers.ts
+++ b/src/ui/app/toolbar/viewOptions/color/helpers.ts
@@ -164,6 +164,7 @@ export function getOperatorsByField(field: DataField): Array<{
       { label: "has any of", value: "has-any-of" },
       { label: "has all of", value: "has-all-of" },
       { label: "has none of", value: "has-none-of" },
+      { label: "contains part of", value: "contains-part-of" },
     ];
   }
 

--- a/src/ui/app/toolbar/viewOptions/color/helpers.ts
+++ b/src/ui/app/toolbar/viewOptions/color/helpers.ts
@@ -164,7 +164,7 @@ export function getOperatorsByField(field: DataField): Array<{
       { label: "has any of", value: "has-any-of" },
       { label: "has all of", value: "has-all-of" },
       { label: "has none of", value: "has-none-of" },
-      { label: "contains part of", value: "contains-part-of" },
+      { label: "has keyword", value: "has-keyword" },
     ];
   }
 

--- a/src/ui/app/toolbar/viewOptions/filter/FilterOptions.svelte
+++ b/src/ui/app/toolbar/viewOptions/filter/FilterOptions.svelte
@@ -18,6 +18,7 @@
   import type { DataField } from "src/lib/dataframe/dataframe";
   import {
     filterOperatorTypes,
+    getFilterOperatorType,
     type FilterDefinition,
     type FilterOperator,
   } from "src/settings/settings";
@@ -55,9 +56,8 @@
     (i: number) =>
     ({ detail }: CustomEvent<string>) => {
       if (
-        filter.conditions[i]?.operator &&
-        filterOperatorTypes[detail as FilterOperator] !==
-          filterOperatorTypes[filter.conditions[i].operator]
+        getFilterOperatorType(detail as FilterOperator) !==
+        getFilterOperatorType(filter.conditions[i]?.operator)
       ) {
         //TODO: potential type conversion here.
         filter = setValue(filter, i, "");

--- a/src/ui/app/toolbar/viewOptions/filter/FilterOptions.svelte
+++ b/src/ui/app/toolbar/viewOptions/filter/FilterOptions.svelte
@@ -18,10 +18,6 @@
   import type { DataField } from "src/lib/dataframe/dataframe";
   import {
     filterOperatorTypes,
-    isNumberFilterOperator,
-    isStringFilterOperator,
-    isDateFilterOperator,
-    isListFilterOperator,
     type FilterDefinition,
     type FilterOperator,
   } from "src/settings/settings";
@@ -58,6 +54,14 @@
   const handleOperatorChange =
     (i: number) =>
     ({ detail }: CustomEvent<string>) => {
+      if (
+        filter.conditions[i]?.operator &&
+        filterOperatorTypes[detail as FilterOperator] !==
+          filterOperatorTypes[filter.conditions[i].operator]
+      ) {
+        //TODO: potential type conversion here.
+        filter = setValue(filter, i, "");
+      }
       filter = setOperator(filter, i, detail as FilterOperator);
       onFilterChange(filter);
     };
@@ -121,40 +125,38 @@
         on:change={handleOperatorChange(i)}
         options={field ? getOperatorsByField(field) : []}
       />
-      {#if filterOperatorTypes[condition.operator] === "binary"}
-        {#if isStringFilterOperator(condition.operator)}
-          <TextInput
-            value={condition.value ?? ""}
+      {#if filterOperatorTypes[condition.operator] === "binary-text"}
+        <TextInput
+          value={condition.value ?? ""}
+          on:blur={handleValueChange(i)}
+        />
+      {:else if filterOperatorTypes[condition.operator] === "binary-number"}
+        <NumberInput
+          value={parseFloat(condition.value ?? "")}
+          on:blur={handleValueChange(i)}
+        />
+      {:else if filterOperatorTypes[condition.operator] === "binary-date"}
+        {#if field?.typeConfig?.time}
+          <DatetimeInput
+            value={dayjs(condition.value ?? "").toDate()}
             on:blur={handleValueChange(i)}
           />
-        {:else if isNumberFilterOperator(condition.operator)}
-          <NumberInput
-            value={parseFloat(condition.value ?? "")}
+        {:else}
+          <DateInput
+            value={dayjs(condition.value ?? "").toDate()}
             on:blur={handleValueChange(i)}
-          />
-        {:else if isDateFilterOperator(condition.operator)}
-          {#if field?.typeConfig?.time}
-            <DatetimeInput
-              value={dayjs(condition.value ?? "").toDate()}
-              on:blur={handleValueChange(i)}
-            />
-          {:else}
-            <DateInput
-              value={dayjs(condition.value ?? "").toDate()}
-              on:blur={handleValueChange(i)}
-            />
-          {/if}
-        {:else if isListFilterOperator(condition.operator)}
-          <TagsInput
-            strict={condition.field === "tags"}
-            unique={true}
-            value={JSON.parse(condition.value ?? "[]")}
-            on:change={(event) => {
-              filter = setValue(filter, i, event.detail);
-              onFilterChange(filter);
-            }}
           />
         {/if}
+      {:else if filterOperatorTypes[condition.operator] === "binary-multitext"}
+        <TagsInput
+          strict={condition.field === "binary-multitext"}
+          unique={true}
+          value={condition.value ? JSON.parse(condition.value) : []}
+          on:change={(event) => {
+            filter = setValue(filter, i, event.detail);
+            onFilterChange(filter);
+          }}
+        />
       {/if}
       <Checkbox
         checked={condition?.enabled ?? true}

--- a/src/ui/app/toolbar/viewOptions/filter/helpers.ts
+++ b/src/ui/app/toolbar/viewOptions/filter/helpers.ts
@@ -81,6 +81,7 @@ export function getOperatorsByField(field: DataField): Array<{
       { label: "has any of", value: "has-any-of" },
       { label: "has all of", value: "has-all-of" },
       { label: "has none of", value: "has-none-of" },
+      { label: "contains part of", value: "contains-part-of" },
     ];
   }
 

--- a/src/ui/app/toolbar/viewOptions/filter/helpers.ts
+++ b/src/ui/app/toolbar/viewOptions/filter/helpers.ts
@@ -81,7 +81,7 @@ export function getOperatorsByField(field: DataField): Array<{
       { label: "has any of", value: "has-any-of" },
       { label: "has all of", value: "has-all-of" },
       { label: "has none of", value: "has-none-of" },
-      { label: "contains part of", value: "contains-part-of" },
+      { label: "has keyword", value: "has-keyword" },
     ];
   }
 


### PR DESCRIPTION
When filtering projects, sometimes I want to be able to match parts of entries of lists.
For example if files in a project have list properties containing `california adventure`, `hotel california` and `californiacation`, then under filter, I can select the option "contains part of" in the drop down, and enter in `califorina`. This will match any files which contain any of the above property entries.

I'm uncertain as to how this filter option should be named, and am open to suggestions that might be more descriptive of what the filter option does.

![image](https://github.com/marcusolsson/obsidian-projects/assets/67801159/658f3bcc-a271-407b-af89-16c795773d88)