### PR TITLE
Fix calculation of month range

### DIFF
--- a/src/ui/views/Calendar/calendar.ts
+++ b/src/ui/views/Calendar/calendar.ts
@@ -90,19 +90,13 @@ export function computeDateInterval(
   interval: CalendarInterval,
   firstDayOfWeek: number
 ): [dayjs.Dayjs, dayjs.Dayjs] {
-  let sow = anchor.startOf("isoWeek");
-  let eow = anchor.endOf("isoWeek");
-
-  const offset = weekdayOffset(sow, firstDayOfWeek);
-
-  sow = sow.subtract(offset, "days");
-  eow = eow.subtract(offset, "days");
-
+  const sow = startOfWeek(anchor, firstDayOfWeek);
+  const eow = endOfWeek(anchor, firstDayOfWeek);
   switch (interval) {
     case "month":
       return [
-        anchor.startOf("month").startOf("week"),
-        anchor.endOf("month").endOf("week"),
+        startOfWeek(anchor.startOf("month"), firstDayOfWeek),
+        endOfWeek(anchor.endOf("month"), firstDayOfWeek),
       ];
     case "2weeks":
       return [sow, eow.add(1, "week")];
@@ -196,17 +190,20 @@ function take<T>(arr: Array<T>, num: number): Array<T> {
   return buffer;
 }
 
-export function weekdayOffset(
+export function startOfWeek(
   date: dayjs.Dayjs,
   firstDayOfWeek: number
-): number {
-  let offset = date.day() - firstDayOfWeek;
+): dayjs.Dayjs {
+  const offset = (7 + date.day() - firstDayOfWeek) % 7;
+  return date.subtract(offset, "days");
+}
 
-  if (offset < 0) {
-    offset += 7;
-  }
-
-  return offset;
+export function endOfWeek(
+  date: dayjs.Dayjs,
+  firstDayOfWeek: number
+): dayjs.Dayjs {
+  const offset = (firstDayOfWeek + 6 - date.day()) % 7;
+  return date.add(offset, "days");
 }
 
 export type LocaleOption = "system" | "obsidian";


### PR DESCRIPTION
A follow-up of #866. Now the month view correctly adapts the start of week config, and an edge case that an extra week would be added in the front when the first day is Sunday and the start-of-week config is also Sunday is solved.

May close #923