### PR TITLE
Add hint on new column button when no status field assigned

### DIFF
--- a/src/lib/stores/translations/en.json
+++ b/src/lib/stores/translations/en.json
@@ -394,8 +394,12 @@
             },
             "board": {
                 "column": {
-                    "add": "Add column",
-                    "placeholder": "New column",
+                    "add": {
+                        "name": "Add column",
+                        "placeholder": "New column",
+                        "no-status-field": "Status field required",
+                        "derived-status-field": "Current status field is read-only"
+                    },
                     "rename": "Rename column",
                     "delete": "Delete column",
                     "expand": "Expand column",

--- a/src/lib/stores/translations/uk.json
+++ b/src/lib/stores/translations/uk.json
@@ -394,8 +394,12 @@
             },
             "board": {
                 "column": {
-                    "add": "Додати стовпчик",
-                    "placeholder": "Новий стовпець",
+                    "add": {
+                        "name": "Додати стовпчик",
+                        "placeholder": "Новий стовпець",
+                        "no-status-field": "Status field required",
+                        "derived-status-field": "Current status field is read-only"
+                    },
                     "rename": "Перейменувати стовпець",
                     "delete": "Видалити стовпець",
                     "expand": "Розгорнути стовпець",

--- a/src/lib/stores/translations/zh-CN.json
+++ b/src/lib/stores/translations/zh-CN.json
@@ -394,8 +394,12 @@
             },
             "board": {
                 "column": {
-                    "add": "新建列表",
-                    "placeholder": "新列表",
+                    "add": {
+                        "name": "新建列表",
+                        "placeholder": "新列表",
+                        "no-status-field": "需要设置状态字段",
+                        "derived-status-field": "该状态字段只读，无法添加列"
+                    },
                     "rename": "重命名列表",
                     "delete": "删除列表",
                     "expand": "展开列表",

--- a/src/ui/views/Board/BoardView.svelte
+++ b/src/ui/views/Board/BoardView.svelte
@@ -449,6 +449,11 @@
     onColumnPin={toggleColumnPin(groupByField)}
     onSortColumns={handleSortColumns(groupByField)}
     {readonly}
+    validateStatusField={() => {
+      if (groupByField?.derived) return "derived-status-field";
+      if (!groupByField) return "no-status-field";
+      return "";
+    }}
     richText={groupByField?.typeConfig?.richText ?? false}
   />
 </BoardOptionsProvider>

--- a/src/ui/views/Board/components/Board/Board.svelte
+++ b/src/ui/views/Board/components/Board/Board.svelte
@@ -33,6 +33,7 @@
   export let onColumnRename: OnColumnRename;
   export let onColumnCollapse: OnColumnCollapse;
   export let onColumnPin: OnColumnPin;
+  export let validateStatusField: () => string;
   export let checkField: string | undefined;
   export let includeFields: DataField[];
   export let customHeader: DataField | undefined;
@@ -132,6 +133,7 @@
         const cols = columns.map((col) => col.id);
         onColumnAdd(cols, name);
       }}
+      fieldError={validateStatusField()}
       onValidate={(name) => {
         if (name === "") return false;
         if (columns.map((col) => col.id).includes(name)) return false;

--- a/src/ui/views/Board/components/Board/NewColumn.svelte
+++ b/src/ui/views/Board/components/Board/NewColumn.svelte
@@ -10,16 +10,20 @@
     inputRef.select();
   }
 
-  let placeholder: string = $i18n.t("components.board.column.placeholder");
+  let placeholder: string = $i18n.t("components.board.column.add.placeholder");
   let value: string = "";
-  $: error = !onValidate(value);
+
+  export let fieldError: string = "";
+  $: tooltip = fieldError
+    ? $i18n.t(`components.board.column.add.${fieldError}`)
+    : "";
 
   export let onColumnAdd: (name: string) => void;
   export let onValidate: (value: string) => boolean;
 
   const addColumn = () => {
     editing = false;
-    if (!error) onColumnAdd(value);
+    if (onValidate(value)) onColumnAdd(value);
     value = "";
   };
 
@@ -55,9 +59,9 @@
     />
   {:else}
     <span class="add-column">
-      <Button variant="plain">
+      <Button variant="plain" disabled={!!fieldError} {tooltip}>
         <Icon name="plus" />
-        {$i18n.t("components.board.column.add")}
+        {$i18n.t("components.board.column.add.name")}
       </Button>
     </span>
   {/if}


### PR DESCRIPTION
Closes #865, #909, #915

Now the add board column button would be hidden on read-only projects, and gone disabled style when there's no status field. Tooltip is added to help users better identify the problem.

Also banned adding columns to a read-only field grouped board (e.g., by file name or path).