### PR TITLE
Fix race condition when editing the "Check" field in the note

### DIFF
--- a/src/ui/views/Board/BoardView.svelte
+++ b/src/ui/views/Board/BoardView.svelte
@@ -71,10 +71,10 @@
 
   const handleRecordCheck =
     (checkField: string): OnRecordCheck =>
-    (record) => {
+    (record, checked) => {
       api.updateRecord(
         updateRecordValues(record, {
-          [checkField]: !record.values[checkField],
+          [checkField]: checked,
         }),
         fields
       );

--- a/src/ui/views/Board/components/Board/CardList.svelte
+++ b/src/ui/views/Board/components/Board/CardList.svelte
@@ -37,8 +37,6 @@
   export let onDrop: OnRecordDrop;
   export let includeFields: DataField[];
   export let checkField: string | undefined;
-  const checked = (item: DataRecord): boolean =>
-    checkField ? (item.values[checkField] as boolean) : false;
   export let customHeader: DataField | undefined;
   export let boardEditing: boolean;
 
@@ -103,10 +101,10 @@
           {#if checkField}
             <span class="checkbox-wrapper">
               <Checkbox
-                checked={checked(item)}
-                on:click={() => {
-                  onRecordCheck(item);
-                }}
+                checked={checkField !== undefined
+                  ? !!item.values[checkField]
+                  : false}
+                on:check={({ detail: checked }) => onRecordCheck(item, checked)}
               />
             </span>
           {/if}

--- a/src/ui/views/Board/components/Board/CardList.svelte
+++ b/src/ui/views/Board/components/Board/CardList.svelte
@@ -104,7 +104,7 @@
             <span class="checkbox-wrapper">
               <Checkbox
                 checked={checked(item)}
-                on:check={() => {
+                on:click={() => {
                   onRecordCheck(item);
                 }}
               />

--- a/src/ui/views/Board/components/Board/types.ts
+++ b/src/ui/views/Board/components/Board/types.ts
@@ -9,7 +9,7 @@ export type Column = {
 };
 
 export type OnRecordClick = (record: DataRecord) => void;
-export type OnRecordCheck = (record: DataRecord) => void;
+export type OnRecordCheck = (record: DataRecord, checked: boolean) => void;
 export type OnRecordAdd = (column: string) => void;
 export type OnRecordDrop = (
   record: DataRecord,

--- a/src/ui/views/Calendar/CalendarView.svelte
+++ b/src/ui/views/Calendar/CalendarView.svelte
@@ -125,11 +125,11 @@
     }
   }
 
-  function handleRecordCheck(record: DataRecord) {
+  function handleRecordCheck(record: DataRecord, checked: boolean) {
     if (booleanField) {
       api.updateRecord(
         updateRecordValues(record, {
-          [booleanField.name]: !record.values[booleanField.name],
+          [booleanField.name]: checked,
         }),
         fields
       );
@@ -272,8 +272,8 @@
               onRecordChange={(record) => {
                 handleRecordChange(date, record);
               }}
-              onRecordCheck={(record) => {
-                handleRecordCheck(record);
+              onRecordCheck={(record, checked) => {
+                handleRecordCheck(record, checked);
               }}
               onRecordAdd={() => {
                 handleRecordAdd(date);

--- a/src/ui/views/Calendar/components/Calendar/Day.svelte
+++ b/src/ui/views/Calendar/components/Calendar/Day.svelte
@@ -35,7 +35,7 @@
   /**
    * onRecordCheck runs when the user Checks / Unchecks a calendar event.
    */
-  export let onRecordCheck: (record: DataRecord) => void;
+  export let onRecordCheck: (record: DataRecord, checked: boolean) => void;
 
   /**
    * onRecordChange runs when the user changes the checked state.

--- a/src/ui/views/Calendar/components/Calendar/EventList.svelte
+++ b/src/ui/views/Calendar/components/Calendar/EventList.svelte
@@ -17,7 +17,7 @@
   export let checkField: string | undefined;
 
   export let onRecordClick: (record: DataRecord) => void;
-  export let onRecordCheck: (record: DataRecord) => void;
+  export let onRecordCheck: (record: DataRecord, checked: boolean) => void;
   export let onRecordChange: (record: DataRecord) => void;
 
   function asOptionalBoolean(value: Optional<DataValue>): Optional<boolean> {
@@ -62,9 +62,7 @@
         checked={checkField !== undefined
           ? asOptionalBoolean(record.values[checkField])
           : undefined}
-        on:check={() => {
-          onRecordCheck(record);
-        }}
+        on:check={({ detail: checked }) => onRecordCheck(record, checked)}
       >
         <InternalLink
           linkText={record.id}


### PR DESCRIPTION
Noticed this weird bug:

- Add a note with a boolean (checkbox) field in the header (eg, `closed`)
- Enable the "Checked" field function in Board view (set Checked to our boolean field, `closed`):

![image](https://github.com/user-attachments/assets/6df50cdb-8369-47b9-9f5a-9a75be58e9b1)

- Open the note in a new tab (Projects tab still loaded)
- Change the value of the `closed` field in the note (not in Board view)

Obsidian freezes, as Projects falls into the following race condition:

1. Note file edit triggers a view update in Svelte
2. Card Checkbox `on:check()` is triggered, since the checked state changed ([call](https://github.com/marcusolsson/obsidian-projects/blob/02ff7cc000b27d1a7d5256b2b695f39fdb13284f/src/ui/views/Board/components/Board/CardList.svelte#L107), [source](https://github.com/marcusolsson/obsidian-svelte/blob/4f1ac18e5df5376ec5cdc57e0d28daba86cea14b/src/lib/Checkbox/Checkbox.svelte#L7))
3. `handleRecordCheck` is triggered, complementing the checked state again ([source](https://github.com/marcusolsson/obsidian-projects/blob/02ff7cc000b27d1a7d5256b2b695f39fdb13284f/src/ui/views/Board/BoardView.svelte#L77))
4. checked state complement causes another file edit trigger again, repeat

Easy fix: only trigger `handleRecordCheck()` when we click the checkbox in Board view, dont respond to all checked field changes