### PR TITLE
Fix platform dependent call on weekInfo

### DIFF
--- a/src/obsidianProjects.d.ts
+++ b/src/obsidianProjects.d.ts
@@ -1,14 +1,13 @@
 import type { DataFrame } from "./lib/dataframe/dataframe";
 
 declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Intl {
     interface Locale {
-      weekInfo: {
-        firstDay: number;
-      };
+      weekInfo?: WeekInfo;
+      getWeekInfo?: () => WeekInfo;
     }
   }
+  type WeekInfo = { firstDay: number; weekend: number[]; minimalDays: number };
 }
 
 declare module "obsidian" {

--- a/src/ui/views/Calendar/calendar.ts
+++ b/src/ui/views/Calendar/calendar.ts
@@ -225,7 +225,15 @@ export function getFirstDayOfWeek(day: FirstDayOfWeek): number {
       return 0;
     case "monday":
       return 1;
-    case "default":
-      return getLocale("obsidian").weekInfo.firstDay;
+    case "default": {
+      const obLocale = getLocale("obsidian");
+      if (obLocale.weekInfo) {
+        return obLocale.weekInfo.firstDay ?? 0;
+      }
+      if (typeof obLocale.getWeekInfo === "function") {
+        return obLocale.getWeekInfo().firstDay ?? 0;
+      }
+      return 0;
+    }
   }
 }


### PR DESCRIPTION
Fixes #939

Node.js only recognizes `Locale.weekInfo`, iOS only takes `Locale.getWeekInfo()`, while Chromium accepts both.